### PR TITLE
docs: add project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Lightspeed Agentic Alerts Adapter
+
+A Go component that polls OpenShift AlertManager for firing alerts and creates `Proposal` CRs (`agentic.openshift.io/v1alpha1`) to trigger automated remediation via the Lightspeed Agentic operator. Stateless, single-replica, create-only design — no internal state, diffs AlertManager vs Kubernetes API each cycle.
+
+## Commands
+
+```sh
+make build          # → ./bin/alerts-adapter
+make test           # go test ./...
+make lint           # golangci-lint run ./...
+make fmt            # go fmt ./...
+make vet            # go vet ./...
+make coverage       # HTML coverage report → coverage.html
+make container-build # podman build
+
+# Run a single test
+go test -run TestFunctionName ./internal/adapter/
+
+# Run a single subtest
+go test -run TestFunctionName/subtest_name ./internal/adapter/
+```
+
+## Architecture
+
+Three internal packages, each behind an interface, wired together in `cmd/alerts-adapter/main.go`:
+
+- **`internal/alertmanager`** — AlertManager API client. Reads bearer token on every call (handles rotation). TLS via in-cluster CA. Implements `adapter.AlertSource`.
+- **`internal/proposal`** — Two concerns: `build.go` translates an alert into a `Proposal` CR (deterministic name from fingerprint, embedded Go template `request.tmpl` for the request field); `client.go` wraps controller-runtime to create/list Proposals. Implements `adapter.ProposalClient`.
+- **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `initialDelay` (5m), with an active (non-terminal) Proposal, or within `cooldownWindow` (1h) of a terminal Proposal. Matching is by `alert-fingerprint` label (first 8 chars).
+
+The Proposal CRD types come from `github.com/openshift/lightspeed-agentic-operator/api`.
+
+## Key design decisions
+
+- Polls (not webhooks) for resilience — restart immediately sees all firing alerts.
+- Proposals always created in `openshift-lightspeed` namespace.
+- 409 AlreadyExists on create is expected and handled as a no-op (returns `false, nil`).
+- Fingerprint prefix (8 chars) is used for both Proposal naming and dedup matching (`proposal.FingerprintLen`).
+- Terminal phases: Completed, Failed, Denied, Escalated.
+
+## Conventions
+
+- Commit messages: [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`).
+- Structured logging with `log/slog` (JSON handler), passed explicitly — no globals except `slog.SetDefault` in main.
+- Interfaces defined in the consumer package (`adapter`), not the provider.
+- Tests use table-driven style.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Getting started
+
+1. Fork and clone the repository
+2. Install prerequisites: Go 1.26+, [golangci-lint](https://golangci-lint.run/)
+3. Run `make test` and `make lint` to verify your setup
+
+## Development workflow
+
+### Proposing changes
+
+This project uses the [OpenSpec](https://github.com/samber/openspec) framework to manage specs and changes. Before starting implementation, propose your change through OpenSpec:
+
+1. Run `/openspec-propose` (or `/opsx:propose`) to create a proposal with design, specs, and tasks
+2. Get the proposal reviewed and approved
+3. Implement the change following the generated tasks
+4. Run `/openspec-verify-change` to verify the implementation matches the spec
+5. Archive the change with `/openspec-archive-change` once merged
+
+Specs live in [`openspec/specs/`](openspec/specs/) and changes are tracked in [`openspec/changes/`](openspec/changes/).
+
+### Code changes
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Ensure all checks pass:
+   ```sh
+   make fmt
+   make vet
+   make lint
+   make test
+   ```
+4. Open a pull request
+
+### Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add alertmanager retry logic
+fix: guard against nil alert fingerprint
+test: cover AlreadyExists path
+docs: update architecture diagram
+refactor: return (bool, error) from CreateProposal
+```
+
+## Code review
+
+Pull requests require approval from a reviewer listed in the [OWNERS](OWNERS) file.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 ### Proposing changes
 
-This project uses the [OpenSpec](https://github.com/samber/openspec) framework to manage specs and changes. Before starting implementation, propose your change through OpenSpec:
+This project uses the [OpenSpec](https://github.com/Fission-AI/OpenSpec) framework to manage specs and changes. Before starting implementation, propose your change through OpenSpec:
 
 1. Run `/openspec-propose` (or `/opsx:propose`) to create a proposal with design, specs, and tasks
 2. Get the proposal reviewed and approved

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Lightspeed Agentic Alerts Adapter
+
+A component that bridges OpenShift cluster alerts into the [Lightspeed Agentic](https://github.com/openshift/lightspeed-agentic-operator) system. It polls the in-cluster AlertManager API for firing alerts and creates `Proposal` custom resources (`agentic.openshift.io/v1alpha1`) to trigger automated analysis and remediation workflows.
+
+## Quick start
+
+### Prerequisites
+
+- Go 1.26+
+- Access to an OpenShift cluster (for deployment)
+- [golangci-lint](https://golangci-lint.run/) (for linting)
+
+### Build
+
+```sh
+make build        # outputs ./bin/alerts-adapter
+```
+
+### Test
+
+```sh
+make test         # run all tests
+make coverage     # generate HTML coverage report
+make lint         # run golangci-lint
+```
+
+### Run locally
+
+```sh
+make run
+```
+
+### Container
+
+```sh
+make container-build
+```
+
+### Deploy to OpenShift
+
+```sh
+kubectl apply -f manifests/
+```
+
+The adapter runs as a single-replica Deployment in the `openshift-lightspeed` namespace, using in-cluster authentication.
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `ALERTMANAGER_URL` | `https://alertmanager-main.openshift-monitoring.svc:9094` | AlertManager API endpoint |
+
+Internal polling parameters (constants in `internal/adapter/adapter.go`):
+
+- **Poll interval**: 30s
+- **Initial delay**: 5 min (minimum time an alert must fire before a Proposal is created)
+- **Cooldown window**: 1 hour (minimum time after a terminal Proposal before retrying)
+
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — design rationale, requirements, deployment model, and future work
+- [openspec/specs/](openspec/specs/) — detailed specs for each subsystem, managed with the [OpenSpec](https://github.com/samber/openspec) framework
+
+## License
+
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Internal polling parameters (constants in `internal/adapter/adapter.go`):
 ## Documentation
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — design rationale, requirements, deployment model, and future work
-- [openspec/specs/](openspec/specs/) — detailed specs for each subsystem, managed with the [OpenSpec](https://github.com/samber/openspec) framework
+- [openspec/specs/](openspec/specs/) — detailed specs for each subsystem, managed with the [OpenSpec](https://github.com/Fission-AI/OpenSpec) framework
 
 ## License
 


### PR DESCRIPTION
Add README, CONTRIBUTING, CLAUDE, and AGENTS files covering
quick start, deployment, OpenSpec workflow, architecture,
and coding conventions.

Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation introducing the Lightspeed Agentic Alerts Adapter, which bridges OpenShift AlertManager alerts into the Lightspeed Agentic operator for automated remediation
  * Included quick start guide, prerequisites, build, test, and deployment instructions with configuration details
  * Added contribution guidelines covering development setup, workflow checks, commit message conventions, and licensing information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->