### PR TITLE
chore: auto-install golangci-lint in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ IMAGE_TAG ?= latest
 GO := go
 GOFLAGS ?=
 LDFLAGS ?=
+GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT = $(shell which golangci-lint 2>/dev/null)
 
-.PHONY: all build test clean lint fmt vet run coverage container-build help
+.PHONY: all build test clean lint fmt vet run coverage container-build help install-lint
 
 all: build
 
@@ -22,8 +24,13 @@ test:
 clean:
 	rm -rf $(BIN_DIR)/$(BINARY_NAME) coverage.out coverage.html
 
-lint:
-	golangci-lint run ./...
+install-lint:
+ifeq ($(GOLANGCI_LINT),)
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+endif
+
+lint: install-lint
+	$(GOLANGCI_LINT) run ./...
 
 fmt:
 	$(GO) fmt ./...


### PR DESCRIPTION
Add install-lint target that installs golangci-lint via go install if not already present. The lint target now depends on it so CI environments get the tool automatically.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now automatically provisions and invokes the project's linting tool during the lint step, removing the need for manual installation.
  * This ensures lint checks run consistently as part of the build process, streamlining development and CI workflows without requiring additional local setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->