### PR TITLE
feat: skip alerts with severity none or info

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -5,6 +5,7 @@ package adapter
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
@@ -106,6 +107,16 @@ func (a *Adapter) reconcile(ctx context.Context) {
 		}
 		alertName := alert.Labels["alertname"]
 
+		if skipSeverity(alert) {
+			a.logger.Debug("alert skipped: low severity",
+				"alertname", alertName,
+				"fingerprint", fingerprint,
+				"severity", alert.Labels["severity"],
+			)
+			skipped++
+			continue
+		}
+
 		if skipInitialDelay(alert, now, a.initialDelay) {
 			a.logger.Debug("alert skipped: initial delay",
 				"alertname", alertName,
@@ -172,6 +183,11 @@ func (a *Adapter) reconcile(ctx context.Context) {
 		"skipped", skipped,
 		"created", created,
 	)
+}
+
+func skipSeverity(alert *models.GettableAlert) bool {
+	sev := strings.ToLower(string(alert.Labels["severity"]))
+	return sev == "none" || sev == "info"
 }
 
 func skipInitialDelay(alert *models.GettableAlert, now time.Time, threshold time.Duration) bool {

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -55,12 +55,20 @@ func quietLogger() *slog.Logger {
 func ptr[T any](v T) *T { return &v }
 
 func makeAlert(name, fingerprint string, startsAt time.Time) *models.GettableAlert {
+	return makeAlertWithSeverity(name, fingerprint, startsAt, "warning")
+}
+
+func makeAlertWithSeverity(name, fingerprint string, startsAt time.Time, severity string) *models.GettableAlert {
 	sa := strfmt.DateTime(startsAt)
+	labels := models.LabelSet{"alertname": name}
+	if severity != "" {
+		labels["severity"] = severity
+	}
 	return &models.GettableAlert{
 		Fingerprint: &fingerprint,
 		StartsAt:    &sa,
 		Alert: models.Alert{
-			Labels: models.LabelSet{"alertname": name, "severity": "warning"},
+			Labels: labels,
 		},
 		Annotations: models.LabelSet{"summary": "test alert"},
 	}
@@ -269,6 +277,85 @@ func TestReconcile(t *testing.T) {
 			if len(pc.created) != tt.wantCreated {
 				t.Errorf("created %d proposals, want %d", len(pc.created), tt.wantCreated)
 			}
+			if pc.createCalls != tt.wantCreateCalls {
+				t.Errorf("CreateProposal called %d times, want %d", pc.createCalls, tt.wantCreateCalls)
+			}
+		})
+	}
+}
+
+func TestSkipSeverity(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		severity string
+		want     bool
+	}{
+		{name: "none is skipped", severity: "none", want: true},
+		{name: "info is skipped", severity: "info", want: true},
+		{name: "None mixed case is skipped", severity: "None", want: true},
+		{name: "INFO uppercase is skipped", severity: "INFO", want: true},
+		{name: "NONE uppercase is skipped", severity: "NONE", want: true},
+		{name: "Info mixed case is skipped", severity: "Info", want: true},
+		{name: "warning is not skipped", severity: "warning", want: false},
+		{name: "critical is not skipped", severity: "critical", want: false},
+		{name: "empty string is not skipped", severity: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alert := makeAlertWithSeverity("TestAlert", "abc123", now, tt.severity)
+			got := skipSeverity(alert)
+			if got != tt.want {
+				t.Errorf("skipSeverity(severity=%q) = %v, want %v", tt.severity, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("missing severity label is not skipped", func(t *testing.T) {
+		alert := &models.GettableAlert{
+			Alert: models.Alert{
+				Labels: models.LabelSet{"alertname": "TestAlert"},
+			},
+		}
+		if skipSeverity(alert) {
+			t.Error("skipSeverity() = true for missing severity label, want false")
+		}
+	})
+}
+
+func TestReconcileSkipsSeverity(t *testing.T) {
+	now := time.Now()
+	oldEnough := now.Add(-10 * time.Minute)
+
+	tests := []struct {
+		name            string
+		severity        string
+		wantCreateCalls int
+	}{
+		{name: "none severity not processed", severity: "none", wantCreateCalls: 0},
+		{name: "info severity not processed", severity: "info", wantCreateCalls: 0},
+		{name: "warning severity processed", severity: "warning", wantCreateCalls: 1},
+		{name: "critical severity processed", severity: "critical", wantCreateCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alert := makeAlertWithSeverity("HighCPU", "abcdef1234567890", oldEnough, tt.severity)
+			as := &fakeAlertSource{alerts: models.GettableAlerts{alert}}
+			pc := &fakeProposalClient{}
+
+			a := &Adapter{
+				alerts:         as,
+				proposals:      pc,
+				initialDelay:   initialDelay,
+				cooldownWindow: cooldownWindow,
+				logger:         quietLogger(),
+			}
+
+			a.reconcile(context.Background())
+
 			if pc.createCalls != tt.wantCreateCalls {
 				t.Errorf("CreateProposal called %d times, want %d", pc.createCalls, tt.wantCreateCalls)
 			}

--- a/openspec/changes/severity-filtering/.openspec.yaml
+++ b/openspec/changes/severity-filtering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/severity-filtering/design.md
+++ b/openspec/changes/severity-filtering/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The adapter's reconcile loop processes all firing alerts from AlertManager, applying three dedup filters (initial delay, active proposal, cooldown). There is no filter based on alert severity. Prometheus alerts carry a `severity` label with common values: `critical`, `warning`, `info`, and `none`. Low-severity alerts (`info`, `none`) are informational and should not trigger automated remediation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Skip alerts with severity `none` or `info` before any Proposal processing.
+- Log skipped alerts at debug level for observability.
+- Keep the filter consistent with the existing skip pattern in the reconcile loop.
+
+**Non-Goals:**
+- Making the set of skipped severities configurable (can be added later if needed).
+- Filtering at the AlertManager API query level (the API doesn't support label-based filtering in query params).
+
+## Decisions
+
+### 1. Filter placement: first check in the reconcile loop
+
+The severity filter will be the first skip check in the reconcile loop, before `skipInitialDelay`. Rationale: severity is a static property of the alert — checking it first avoids unnecessary work in downstream filters (initial delay, active proposal lookup, cooldown). This is the cheapest check.
+
+**Alternative considered:** Filtering in `alertmanager.GetAlerts()` after the API call. Rejected because filtering logic belongs in the adapter (where all other skip decisions live), not in the API client.
+
+### 2. Hardcoded skip set, not configurable
+
+The skipped severities (`none`, `info`) are hardcoded as constants. Rationale: these are well-established Prometheus conventions. A configurable list adds complexity without clear value today. If needed later, it can be extracted to a config parameter.
+
+**Alternative considered:** Environment variable for skipped severities. Rejected as premature — the skip set is unlikely to change across deployments.
+
+### 3. Case-insensitive comparison
+
+Severity labels are compared case-insensitively (lowercase before matching). Rationale: while Prometheus convention is lowercase, AlertManager rules can set arbitrary label values. Defensive normalization prevents silent misconfiguration.
+
+## Risks / Trade-offs
+
+- **[Risk] Alert with missing severity label** → Treated as non-skipped (processed normally). Missing severity is unusual but shouldn't block remediation.
+- **[Trade-off] Hardcoded vs configurable** → Simpler code now, but requires a code change to adjust the skip set. Acceptable given stable Prometheus conventions.

--- a/openspec/changes/severity-filtering/proposal.md
+++ b/openspec/changes/severity-filtering/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The adapter currently processes all firing alerts regardless of severity. Alerts with severity `none` or `info` are typically informational and do not warrant automated remediation via Proposal CRs. Processing them creates unnecessary Proposals that clutter the system and waste agentic operator resources on non-actionable alerts.
+
+## What Changes
+
+- Add severity-based filtering to the reconcile loop so alerts with severity `none` or `info` are skipped before Proposal creation.
+- Log skipped alerts at debug level for observability.
+
+## Capabilities
+
+### New Capabilities
+- `severity-filtering`: Filter out alerts based on their severity label during reconciliation. Alerts with severity `none` or `info` are skipped.
+
+### Modified Capabilities
+
+## Impact
+
+- `internal/adapter/adapter.go` — new severity check in the reconcile loop alongside existing dedup filters.
+- No API changes, no new dependencies, no breaking changes.
+- Existing alerts with severity `warning`, `critical`, or any other value continue to be processed as before.

--- a/openspec/changes/severity-filtering/specs/severity-filtering/spec.md
+++ b/openspec/changes/severity-filtering/specs/severity-filtering/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Skip alerts with low severity
+The adapter SHALL skip alerts whose `severity` label is `none` or `info` (case-insensitive) during reconciliation. Skipped alerts MUST NOT result in Proposal CR creation. The severity check SHALL be performed before all other skip checks (initial delay, active proposal, cooldown).
+
+#### Scenario: Alert with severity none is skipped
+- **WHEN** an alert has severity label `none`
+- **THEN** the adapter skips the alert and does not create a Proposal
+
+#### Scenario: Alert with severity info is skipped
+- **WHEN** an alert has severity label `info`
+- **THEN** the adapter skips the alert and does not create a Proposal
+
+#### Scenario: Alert with severity warning is processed
+- **WHEN** an alert has severity label `warning`
+- **THEN** the adapter processes the alert through remaining filters and may create a Proposal
+
+#### Scenario: Alert with severity critical is processed
+- **WHEN** an alert has severity label `critical`
+- **THEN** the adapter processes the alert through remaining filters and may create a Proposal
+
+#### Scenario: Case-insensitive severity matching
+- **WHEN** an alert has severity label `Info` or `NONE` (mixed case)
+- **THEN** the adapter skips the alert
+
+#### Scenario: Alert with missing severity label is processed
+- **WHEN** an alert has no `severity` label
+- **THEN** the adapter processes the alert through remaining filters (does not skip)
+
+### Requirement: Log skipped alerts
+The adapter SHALL log each severity-skipped alert at debug level, including the alert name, fingerprint, and severity value.
+
+#### Scenario: Debug log for skipped alert
+- **WHEN** an alert is skipped due to low severity
+- **THEN** the adapter logs a debug message with alertname, fingerprint, and severity

--- a/openspec/changes/severity-filtering/tasks.md
+++ b/openspec/changes/severity-filtering/tasks.md
@@ -1,0 +1,9 @@
+## 1. Core Implementation
+
+- [x] 1.1 Add `skipSeverity` function to `internal/adapter/adapter.go` that returns true for alerts with severity `none` or `info` (case-insensitive), false otherwise (including missing label)
+- [x] 1.2 Integrate severity check as the first skip in the `reconcile` loop, before `skipInitialDelay`, with debug logging (alertname, fingerprint, severity)
+
+## 2. Tests
+
+- [x] 2.1 Add unit tests for `skipSeverity` covering: none, info, warning, critical, mixed-case, empty string, and missing severity label
+- [x] 2.2 Add reconcile-level test verifying that alerts with severity `none`/`info` do not result in Proposal creation


### PR DESCRIPTION
Add severity-based filtering to the reconcile loop so that informational alerts (severity "none" or "info") are skipped before Proposal creation. The check is case-insensitive and runs before all other filters. Alerts with missing severity labels are processed normally.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert severity-based filtering: Alerts with low/no severity (labeled as "none" or "info") are now automatically filtered and skipped from processing during reconciliation, preventing these alerts from triggering proposals. Only alerts with "warning", "critical", or other meaningful severity levels proceed. Severity matching is case-insensitive. Debug logging provides visibility into filtered alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->