### PR TITLE
docs: add OpenSpec change for alert grouping

### DIFF
--- a/openspec/changes/alert-grouping/design.md
+++ b/openspec/changes/alert-grouping/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The adapter polls AlertManager for firing alerts and creates Proposal CRs for automated remediation. Currently it uses the `/api/v2/alerts` endpoint which returns a flat list of individual alerts, and creates one Proposal per alert. AlertManager's `/api/v2/alerts/groups` endpoint returns alerts pre-grouped according to the user's `group_by` route configuration (typically `['alertname', 'namespace']`). Switching to this endpoint allows the adapter to create one Proposal per group of related alerts.
+
+The go-swagger client already provides `c.api.Alertgroup.GetAlertGroups()` returning `models.AlertGroups` (`[]*AlertGroup`), where each `AlertGroup` contains `Labels` (the shared group labels), `Receiver`, and `Alerts` (`[]*GettableAlert` — the same type used today).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the flat alerts endpoint with the groups endpoint.
+- Create one Proposal per alert group, with a request template that presents all alerts in the group.
+- Fall back to per-alert Proposal creation for groups with empty labels (cluster-scoped alerts).
+- Replace fingerprint-based deduplication with a uniform group-hash scheme.
+- Adapt severity filtering, initial delay, and dedup checks for group-level processing.
+- Collect all distinct namespaces from alerts in the group into `spec.targetNamespaces`.
+
+**Non-Goals:**
+- Adapter-side re-grouping or sub-grouping of AlertManager groups.
+- Max group size caps or other safeguards against broad grouping — the user is expected to configure `group_by` appropriately.
+- Backward compatibility with existing Proposals (not yet deployed to production).
+- Making the grouping behavior configurable or toggleable.
+
+## Decisions
+
+### 1. Use AlertManager's groups endpoint, trust user's `group_by` config
+
+The adapter switches from `GetAlerts()` to `GetAlertGroups()` and uses the groups as-is. The assumption is that the user configures AlertManager's `group_by` setting appropriately (e.g., `['alertname', 'namespace']`). The adapter does not re-group or validate the grouping.
+
+**Alternative considered:** Fetching flat alerts and grouping on the adapter side by configurable labels. Rejected because it duplicates AlertManager's existing grouping logic and ignores the user's routing configuration.
+
+### 2. Empty group labels → per-alert fallback
+
+When a group has empty labels (typically cluster-scoped alerts with no `namespace` label under the default OpenShift config of `group_by: ['namespace']`), each alert in that group is processed individually, producing one Proposal per alert. This prevents unrelated cluster-scoped alerts from being bundled into a single unfocused Proposal.
+
+**Alternative considered:** Skipping empty-label groups entirely. Rejected because cluster-scoped alerts still need remediation.
+
+### 3. Uniform group hash for dedup
+
+All dedup matching uses a single label: `agentic.openshift.io/alert-group-hash`.
+
+- **Grouped Proposals:** hash is `sha256(sorted "key=value" pairs from group labels)[:8]`.
+- **Fallback per-alert Proposals:** hash is `fingerprint[:8]` (the alert's existing fingerprint, which is already a hash of the alert's label set).
+
+This replaces the current `agentic.openshift.io/alert-fingerprint` label. One code path handles all dedup.
+
+**Alternative considered:** Keeping both `alert-fingerprint` and `alert-group-hash` labels for a transition period. Rejected because the system is not yet in production.
+
+### 4. Severity filtering: per-alert within group
+
+Alerts with severity `none` or `info` are filtered out from the group before Proposal creation. If all alerts in a group are filtered out, the entire group is skipped. The Proposal is built from the remaining alerts only.
+
+### 5. Initial delay: any alert in group passes
+
+A group passes the initial delay check if any alert in the group has been firing longer than the threshold. Rationale: the group exists because AlertManager considers the alerts related, and if at least one alert has persisted, the situation warrants a Proposal.
+
+### 6. Target namespaces from all alerts in the group
+
+The Proposal's `spec.targetNamespaces` is populated with all distinct namespace values collected from the individual alerts' `namespace` labels. Currently the field is set from a single alert; with grouping, alerts in the same group may span multiple namespaces (depending on the `group_by` configuration). If no alert in the group has a `namespace` label, `targetNamespaces` is omitted.
+
+### 7. Proposal metadata
+
+**Labels:**
+- `agentic.openshift.io/source: alertmanager`
+- `agentic.openshift.io/alert-group-hash: <hash>` — dedup key
+- `agentic.openshift.io/alert-severity: <highest>` — highest severity across all alerts in the group
+
+**Annotations:**
+- `agentic.openshift.io/alert-names: '["AlertA","AlertB"]'` — JSON array of distinct alert names in the group
+- `agentic.openshift.io/alert-starts-at: <earliest>` — earliest `startsAt` across all alerts in the group
+- `agentic.openshift.io/alert-summary: <summary>` — summary from the first alert (or combined)
+
+The `alert-names` annotation uses a JSON array format since annotation values have no length or character restrictions, unlike labels.
+
+### 8. Proposal naming
+
+- **Grouped:** `{first-alertname}-{namespace}-{hash}` or `{first-alertname}-{hash}` if no namespace in group labels. Uses the first alert name from sorted distinct names for readability.
+- **Fallback:** Same as current: `{alertname}-{namespace}-{fingerprint[:8]}` or `{alertname}-{fingerprint[:8]}`.
+
+### 9. Request template
+
+The template changes from describing a single alert to listing all alerts in the group, prefixed with the group labels. Each alert's full details (severity, runbook URL, namespace, summary, description, labels) are included so the analysis agent has the complete symptom picture.
+
+## Risks / Trade-offs
+
+- **[Risk] User has not configured `group_by` properly** — With the default OpenShift config (`group_by: ['namespace']`), unrelated alert types in the same namespace are grouped together. The adapter trusts the user's configuration. This should be documented as a prerequisite.
+- **[Trade-off] No adapter-side grouping control** — Simpler implementation, but the adapter has no way to override AlertManager's grouping. Acceptable because the grouping is an AlertManager concern.
+- **[Risk] Large groups produce long request templates** — If a group contains many alerts, the rendered request could be very long. No cap is applied; the agent is expected to handle it.

--- a/openspec/changes/alert-grouping/proposal.md
+++ b/openspec/changes/alert-grouping/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The adapter currently creates one Proposal CR per individual alert. When multiple instances of the same alert fire simultaneously (e.g., 5 pods crash-looping in the same namespace), this produces 5 independent Proposals that each attempt to remediate the same root cause. This creates noise, wastes agentic operator resources, and prevents the agent from seeing the full symptom picture.
+
+AlertManager already groups related alerts based on the user's `group_by` route configuration. The adapter should leverage this grouping to create one Proposal per alert group, giving the agentic operator a holistic view of related symptoms for better root-cause analysis and remediation.
+
+## What Changes
+
+- Switch from AlertManager's `/api/v2/alerts` (flat list) to `/api/v2/alerts/groups` (pre-grouped) endpoint.
+- Create one Proposal per alert group instead of one per alert.
+- For groups with empty labels (cluster-scoped alerts that AlertManager cannot meaningfully group), fall back to per-alert Proposal creation.
+- Replace fingerprint-based deduplication with a uniform group-hash-based scheme.
+- Update the request template to present all alerts in a group to the analysis agent.
+- Update Proposal labels and annotations to reflect group-level metadata.
+
+## Capabilities
+
+### Modified Capabilities
+- `alert-retrieval`: Retrieve alert groups instead of individual alerts from AlertManager.
+- `poll-loop`: Reconcile loop iterates over alert groups. Dedup, initial delay, and severity filtering adapted for groups. Empty-label groups fall back to per-alert processing.
+- `proposal-building`: Build Proposals from alert groups. New naming, labeling, and request template for grouped alerts.
+
+## Impact
+
+- `internal/alertmanager/client.go` — switch from `GetAlerts` to `GetAlertGroups` API call; return type changes to `models.AlertGroups`.
+- `internal/adapter/adapter.go` — `AlertSource` interface changes return type; `reconcile` iterates groups, applies severity filtering per-alert within groups, initial delay passes if any alert qualifies, dedup by `alert-group-hash` label.
+- `internal/proposal/build.go` — new `BuildFromGroup` function alongside updated `Build` for single-alert fallback; group hash computation; new label/annotation scheme.
+- `internal/proposal/request.tmpl` — multi-alert template listing all alerts in the group with their details.
+- `internal/adapter/adapter_test.go` — tests updated for group-based flow.
+- `internal/proposal/build_test.go` — tests for group building, hash computation, fallback path.

--- a/openspec/changes/alert-grouping/specs/alert-retrieval/spec.md
+++ b/openspec/changes/alert-grouping/specs/alert-retrieval/spec.md
@@ -1,0 +1,70 @@
+## Purpose
+Retrieve active alert groups from the in-cluster Alertmanager so the adapter can translate them into actionable Proposal resources.
+
+## Requirements
+### Requirement: Retrieve active alert groups from Alertmanager
+The system SHALL query the Alertmanager groups API in the OpenShift cluster and return the set of currently active alert groups using the types provided by the Alertmanager client library.
+
+#### Scenario: Successful alert group retrieval
+- **WHEN** the adapter queries Alertmanager and alerts are firing
+- **THEN** the system returns a list of alert groups, each containing shared group labels and a list of alerts with their name, severity, state, labels, annotations, and firing start time
+
+#### Scenario: No active alerts
+- **WHEN** the adapter queries Alertmanager and no alerts are currently firing
+- **THEN** the system returns an empty list and no error
+
+#### Scenario: Alertmanager unreachable
+- **WHEN** the adapter attempts to query Alertmanager and the service is unreachable
+- **THEN** the system returns an error indicating the Alertmanager could not be contacted
+
+#### Scenario: Authentication failure
+- **WHEN** the adapter's request to Alertmanager is rejected due to insufficient permissions or an invalid token
+- **THEN** the system returns an error indicating an authentication or authorization failure
+
+### Requirement: Authenticate using in-cluster ServiceAccount credentials
+The system SHALL authenticate to the Alertmanager API using the pod's ServiceAccount bearer token and trust the OpenShift service CA certificate (`service-ca.crt`) for TLS verification.
+
+#### Scenario: Valid in-cluster credentials
+- **WHEN** the adapter runs inside a cluster with a valid ServiceAccount token and service CA certificate
+- **THEN** the system uses the token for authentication and the service CA for TLS without additional configuration
+
+#### Scenario: Missing ServiceAccount token
+- **WHEN** the ServiceAccount token file is not present at the expected path
+- **THEN** the system returns an error indicating the token could not be loaded
+
+### Requirement: Configurable Alertmanager URL
+The system SHALL allow the Alertmanager URL to be configured via an environment variable, with a default of `https://alertmanager-main.openshift-monitoring.svc:9094`.
+
+#### Scenario: Custom URL provided
+- **WHEN** the environment variable for the Alertmanager URL is set
+- **THEN** the system uses the provided URL instead of the default
+
+#### Scenario: No custom URL
+- **WHEN** the environment variable for the Alertmanager URL is not set
+- **THEN** the system uses the default in-cluster Alertmanager URL
+
+### Requirement: Filter for actionable alerts
+The system SHALL request only active, non-silenced, non-inhibited alert groups from the Alertmanager API so the adapter never processes suppressed alerts.
+
+#### Scenario: Silenced alerts excluded
+- **WHEN** an alert is silenced in Alertmanager
+- **THEN** the alert is not included in the response
+
+#### Scenario: Inhibited alerts excluded
+- **WHEN** an alert is inhibited by another alert in Alertmanager
+- **THEN** the alert is not included in the response
+
+#### Scenario: Resolved alerts excluded
+- **WHEN** an alert has resolved and is no longer active
+- **THEN** the alert is not included in the response
+
+### Requirement: Log retrieved alert groups on startup
+The system SHALL fetch alert groups during startup and log a summary of the results using structured logging.
+
+#### Scenario: Alert groups fetched and logged
+- **WHEN** the adapter starts and successfully retrieves alert groups
+- **THEN** the system logs the number of groups and alerts retrieved
+
+#### Scenario: Alert group retrieval fails on startup
+- **WHEN** the adapter starts and alert group retrieval fails
+- **THEN** the system logs the error and exits with a non-zero status code

--- a/openspec/changes/alert-grouping/specs/poll-loop/spec.md
+++ b/openspec/changes/alert-grouping/specs/poll-loop/spec.md
@@ -1,0 +1,84 @@
+## Purpose
+Continuously poll AlertManager for firing alert groups and create Proposal CRs, with stateless deduplication to avoid duplicate or premature Proposals.
+
+## Requirements
+### Requirement: Poll AlertManager on a fixed interval
+The system SHALL poll AlertManager every 30 seconds for firing alert groups and process each group against the deduplication rules.
+
+#### Scenario: Normal poll cycle
+- **WHEN** the poll interval elapses
+- **THEN** the system fetches alert groups from AlertManager, lists existing Proposals, applies dedup rules per group, and creates Proposals for qualifying groups
+
+#### Scenario: AlertManager unreachable during poll
+- **WHEN** the AlertManager API returns an error during a poll cycle
+- **THEN** the system logs the error and skips the cycle; the next poll retries
+
+#### Scenario: Kubernetes API unreachable during poll
+- **WHEN** the Kubernetes API returns an error during proposal listing or creation
+- **THEN** the system logs the error and skips the cycle; the next poll retries
+
+### Requirement: Process alert groups
+The system SHALL iterate over alert groups returned by AlertManager. For groups with non-empty labels, the system creates one Proposal per group. For groups with empty labels, the system falls back to creating one Proposal per individual alert in the group.
+
+#### Scenario: Group with non-empty labels
+- **WHEN** an alert group has non-empty shared labels (e.g., `alertname`, `namespace`)
+- **THEN** the system creates a single Proposal for the entire group
+
+#### Scenario: Group with empty labels (cluster-scoped fallback)
+- **WHEN** an alert group has empty shared labels
+- **THEN** the system processes each alert in the group individually, creating one Proposal per alert
+
+### Requirement: Filter low-severity alerts within groups
+The system SHALL filter out alerts with severity `none` or `info` from each group before Proposal creation. If no alerts remain after filtering, the group is skipped.
+
+#### Scenario: Group with all low-severity alerts
+- **WHEN** all alerts in a group have severity `none` or `info`
+- **THEN** the entire group is skipped and logged at Debug level
+
+#### Scenario: Group with mixed severities
+- **WHEN** a group contains both low-severity and actionable alerts
+- **THEN** the low-severity alerts are removed and the Proposal is built from the remaining alerts
+
+### Requirement: Skip transient alert groups (initial delay)
+The system SHALL not create a Proposal for an alert group where no alert has been firing for at least 5 minutes.
+
+#### Scenario: No alert in group exceeds initial delay
+- **WHEN** all alerts in the group have `now - startsAt` less than 5 minutes
+- **THEN** the group is skipped and logged at Debug level
+
+#### Scenario: At least one alert exceeds initial delay
+- **WHEN** at least one alert in the group has `now - startsAt` of 5 minutes or more
+- **THEN** the group passes the initial delay check
+
+### Requirement: Skip groups with active Proposals
+The system SHALL not create a Proposal for an alert group that already has an active (non-terminal) Proposal, identified by matching the `alert-group-hash` label.
+
+#### Scenario: Active proposal exists for group
+- **WHEN** a Proposal with matching `alert-group-hash` label exists and its phase is non-terminal
+- **THEN** the group is skipped and logged at Debug level
+
+#### Scenario: No proposal exists for group
+- **WHEN** no Proposal with matching `alert-group-hash` label exists
+- **THEN** the group passes the active-proposal check
+
+### Requirement: Skip groups within cooldown window
+The system SHALL not create a Proposal for an alert group that has a terminal Proposal (Completed, Failed, Denied, Escalated) within the cooldown window of 1 hour.
+
+#### Scenario: Terminal proposal within cooldown
+- **WHEN** a Proposal with matching `alert-group-hash` label is in a terminal phase and its terminal condition's `LastTransitionTime` is less than 1 hour ago
+- **THEN** the group is skipped and logged at Debug level
+
+#### Scenario: Terminal proposal outside cooldown
+- **WHEN** a Proposal with matching `alert-group-hash` label is in a terminal phase and its terminal condition's `LastTransitionTime` is 1 hour or more ago
+- **THEN** the group passes the cooldown check
+
+### Requirement: Shut down gracefully on OS signals
+The system SHALL exit cleanly when it receives SIGTERM or SIGINT, completing any in-flight poll cycle before stopping.
+
+#### Scenario: SIGTERM received while idle
+- **WHEN** the adapter receives SIGTERM between poll cycles
+- **THEN** the adapter exits with status code 0
+
+#### Scenario: SIGINT received during poll
+- **WHEN** the adapter receives SIGINT during a poll cycle
+- **THEN** the adapter completes or cancels the in-flight cycle and exits with status code 0

--- a/openspec/changes/alert-grouping/specs/proposal-building/spec.md
+++ b/openspec/changes/alert-grouping/specs/proposal-building/spec.md
@@ -1,0 +1,118 @@
+## Purpose
+Translate Alertmanager alert groups into Proposal custom resources so the agentic operator can act on firing alerts through its analyze-execute-verify workflow.
+
+## Requirements
+### Requirement: Build a Proposal CR from an alert group
+The system SHALL convert an Alertmanager `AlertGroup` into a `Proposal` custom resource with deterministic naming, Kubernetes-safe metadata, a templated request listing all alerts, and `spec.targetNamespaces` populated from all alerts' namespace labels.
+
+#### Scenario: Group with single alert type and namespace
+- **WHEN** the group labels include `alertname` and `namespace` and all alerts share the same alert name
+- **THEN** the Proposal name is `{alertname}-{namespace}-{grouphash}`, `spec.targetNamespaces` is set to `[namespace]`, and the request lists all alerts in the group
+
+#### Scenario: Group spanning multiple namespaces
+- **WHEN** alerts in the group have different `namespace` labels
+- **THEN** `spec.targetNamespaces` contains all distinct namespaces from the alerts
+
+#### Scenario: Group with no namespace
+- **WHEN** no alert in the group has a `namespace` label
+- **THEN** `spec.targetNamespaces` is omitted
+
+#### Scenario: Deterministic naming produces idempotent creates
+- **WHEN** the same alert group is passed to BuildFromGroup twice
+- **THEN** both calls produce Proposals with identical names, enabling Kubernetes 409 deduplication
+
+### Requirement: Build a Proposal CR from a single alert (fallback)
+The system SHALL convert a single Alertmanager `GettableAlert` into a `Proposal` custom resource using the alert's fingerprint as the group hash, for alerts that cannot be meaningfully grouped (empty group labels).
+
+#### Scenario: Cluster-scoped alert fallback
+- **WHEN** an alert comes from a group with empty labels
+- **THEN** the Proposal name is `{alertname}-{fingerprint[:8]}`, the `alert-group-hash` label is set to `fingerprint[:8]`, and the request describes the single alert
+
+#### Scenario: Alert with namespace in fallback path
+- **WHEN** a fallback alert has a `namespace` label
+- **THEN** the Proposal name is `{alertname}-{namespace}-{fingerprint[:8]}` and `spec.targetNamespaces` is set to `[namespace]`
+
+### Requirement: Compute deterministic group hash
+The system SHALL compute a deterministic hash from an alert group's shared labels by sorting key=value pairs alphabetically and taking the first 8 characters of the SHA-256 hex digest.
+
+#### Scenario: Same labels produce same hash
+- **WHEN** two groups have identical label sets
+- **THEN** their computed hashes are identical
+
+#### Scenario: Different labels produce different hashes
+- **WHEN** two groups have different label sets
+- **THEN** their computed hashes differ
+
+### Requirement: Sanitize alert data for Kubernetes metadata
+The system SHALL sanitize alert values to conform to Kubernetes naming and label restrictions.
+
+#### Scenario: Proposal name contains invalid DNS characters
+- **WHEN** the alertname or namespace contains characters not allowed in DNS subdomain names
+- **THEN** those characters are replaced with hyphens and the result is lowercased
+
+#### Scenario: Proposal name exceeds 253 characters
+- **WHEN** the computed name would exceed 253 characters
+- **THEN** the alertname component is truncated to fit within the limit while preserving the namespace and hash suffix
+
+#### Scenario: Label value exceeds 63 characters
+- **WHEN** an alert field used as a label value exceeds 63 characters
+- **THEN** the value is truncated to 63 characters and trimmed of trailing non-alphanumeric characters
+
+### Requirement: Set group-level labels and annotations
+The system SHALL set labels for filtering/dedup and annotations for traceability on the Proposal.
+
+#### Scenario: Labels set correctly
+- **WHEN** a Proposal is built from a group
+- **THEN** labels include `source=alertmanager`, `alert-group-hash=<hash>`, and `alert-severity=<highest severity in group>`
+
+#### Scenario: Annotations set correctly
+- **WHEN** a Proposal is built from a group
+- **THEN** annotations include `alert-names` (JSON array of distinct alert names), `alert-starts-at` (earliest startsAt in group), and `alert-summary`
+
+#### Scenario: Severity ranking
+- **WHEN** a group contains alerts with severities `warning` and `critical`
+- **THEN** the `alert-severity` label is set to `critical`
+
+### Requirement: Render a structured request from alert group data
+The system SHALL render the `spec.request` field using an embedded Go template that lists the group labels and all alerts with their individual details (name, severity, namespace, summary, description, runbook URL, labels).
+
+#### Scenario: Group with multiple alerts
+- **WHEN** the group contains 3 alerts
+- **THEN** the rendered request includes group labels and all 3 alerts with their full details
+
+#### Scenario: Group with single alert
+- **WHEN** the group contains 1 alert
+- **THEN** the rendered request includes the group labels and the single alert's details
+
+### Requirement: Configure all three workflow steps
+The system SHALL set the analysis, execution, and verification steps on the Proposal, each referencing the `default` agent.
+
+#### Scenario: Built Proposal has full workflow
+- **WHEN** a Proposal is built from any alert group
+- **THEN** `spec.analysis`, `spec.execution`, and `spec.verification` all have `agent` set to `"default"`
+
+### Requirement: List existing Proposals by source
+The system SHALL list Proposal CRs filtered by the `agentic.openshift.io/source=alertmanager` label to support deduplication queries.
+
+#### Scenario: Proposals exist
+- **WHEN** ListProposals is called and Proposals with the alertmanager source label exist
+- **THEN** the system returns the matching Proposals with their status conditions
+
+#### Scenario: No proposals exist
+- **WHEN** ListProposals is called and no Proposals with the alertmanager source label exist
+- **THEN** the system returns an empty list and no error
+
+### Requirement: Create Proposal resources in the cluster
+The system SHALL provide a Kubernetes client that creates Proposal CRs using controller-runtime with in-cluster config. The client SHALL return a boolean indicating whether the Proposal was created, and treat 409 AlreadyExists as a non-error.
+
+#### Scenario: Successful creation
+- **WHEN** CreateProposal is called with a valid Proposal
+- **THEN** the Proposal is created in the cluster, returns true and no error
+
+#### Scenario: Proposal already exists
+- **WHEN** the Kubernetes API returns 409 AlreadyExists
+- **THEN** CreateProposal logs at Info level and returns false and no error
+
+#### Scenario: Creation failure
+- **WHEN** the Kubernetes API returns a non-409 error
+- **THEN** CreateProposal returns false and a wrapped error with context

--- a/openspec/changes/alert-grouping/tasks.md
+++ b/openspec/changes/alert-grouping/tasks.md
@@ -1,0 +1,28 @@
+## 1. AlertManager client: switch to groups endpoint
+
+- [ ] 1.1 Change `GetAlerts` to `GetAlertGroups` in `internal/alertmanager/client.go`, calling `c.api.Alertgroup.GetAlertGroups()` with the same filter params (active=true, silenced=false, inhibited=false); return type changes to `models.AlertGroups`
+- [ ] 1.2 Update `internal/alertmanager/client_test.go` for the new return type
+
+## 2. Proposal building: group support
+
+- [ ] 2.1 Add `GroupHash` function to `internal/proposal/build.go` that computes `sha256(sorted "key=value" pairs)[:8]` from a `models.LabelSet`
+- [ ] 2.2 Add `BuildFromGroup` function that takes `*models.AlertGroup` and builds a Proposal with: group-hash-based naming, `alert-group-hash` label, `alert-severity` label (highest), `alert-names` annotation (JSON array), `alert-starts-at` annotation (earliest), `alert-summary` annotation, and `spec.targetNamespaces` collected from all alerts' `namespace` labels
+- [ ] 2.3 Update `Build` (single alert) to use the new `alert-group-hash` label (using `fingerprint[:8]` as hash) instead of `alert-fingerprint`, for the fallback path
+- [ ] 2.4 Update `request.tmpl` to a multi-alert template that lists group labels and all alerts with their individual details
+- [ ] 2.5 Add tests for `GroupHash`, `BuildFromGroup` (multi-alert group, single-alert group, mixed namespaces, no namespace, severity ranking, alert-names annotation format)
+- [ ] 2.6 Update existing `Build` tests for the new label scheme
+
+## 3. Adapter: group-based reconcile loop
+
+- [ ] 3.1 Change `AlertSource` interface from `GetAlerts(ctx) (models.GettableAlerts, error)` to `GetAlertGroups(ctx) (models.AlertGroups, error)`
+- [ ] 3.2 Rewrite `reconcile` to iterate over groups: for each group, check if group labels are empty (fallback to per-alert) or non-empty (grouped path)
+- [ ] 3.3 Implement group-level severity filtering: filter out `none`/`info` alerts from the group, skip group if empty after filtering
+- [ ] 3.4 Implement group-level initial delay: pass if any alert in the group exceeds the threshold
+- [ ] 3.5 Update `hasActiveProposal` and `inCooldown` to match by `alert-group-hash` label instead of `alert-fingerprint`
+- [ ] 3.6 Update `internal/adapter/adapter_test.go` with group-based test cases: grouped creation, empty-label fallback, severity filtering within group, initial delay with mixed ages, dedup by group hash, cooldown by group hash
+
+## 4. Cleanup
+
+- [ ] 4.1 Remove `FingerprintLen` constant and `fingerprintPrefix` helper from `internal/proposal/build.go` (replaced by `GroupHash`; the adapter no longer references fingerprint length directly)
+- [ ] 4.2 Remove old label constants (`labelFingerprint`, `labelAlertName`, `labelSeverity`) that are replaced by the new scheme
+- [ ] 4.3 Run `make lint` and `make test` to verify all changes


### PR DESCRIPTION
Add proposal, design, tasks, and updated specs for switching from per-alert to group-based Proposal creation using AlertManager's /api/v2/alerts/groups endpoint.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications and design documentation for alert-grouping functionality, including alert retrieval, polling loop behavior, proposal generation, and implementation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->