### PR TITLE
fix: cap Proposal name at 63 chars to fit Kubernetes label limit

### DIFF
--- a/internal/proposal/build.go
+++ b/internal/proposal/build.go
@@ -29,7 +29,6 @@ const (
 	sourceValue = "alertmanager"
 
 	maxLabelValueLen = 63
-	maxNameLen       = 253
 	// FingerprintLen is the number of characters used from the alert fingerprint
 	// for labels and dedup matching. Exported for use by the adapter package.
 	FingerprintLen = 8
@@ -102,6 +101,8 @@ func Build(a *models.GettableAlert) (*agenticv1alpha1.Proposal, error) {
 
 // buildName produces a deterministic DNS-compatible name: {alertname}-{namespace}-{fingerprint[:8]}
 // or {alertname}-{fingerprint[:8]} for cluster-scoped alerts.
+// The name is capped at 63 characters because the agentic operator uses it as a
+// Kubernetes label value, which has a 63-byte limit.
 func buildName(alertName, namespace, fingerprint string) string {
 	fp := fingerprint
 	if len(fp) > FingerprintLen {
@@ -115,18 +116,18 @@ func buildName(alertName, namespace, fingerprint string) string {
 		ns := strings.ToLower(namespace)
 		ns = invalidDNSChars.ReplaceAllString(ns, "-")
 		combined := name + "-" + ns + "-" + fp
-		if len(combined) <= maxNameLen {
+		if len(combined) <= maxLabelValueLen {
 			return combined
 		}
-		available := max(maxNameLen-len(ns)-len(fp)-2, 1)
+		available := max(maxLabelValueLen-len(ns)-len(fp)-2, 1)
 		return truncateDNS(name, available) + "-" + ns + "-" + fp
 	}
 
 	combined := name + "-" + fp
-	if len(combined) <= maxNameLen {
+	if len(combined) <= maxLabelValueLen {
 		return combined
 	}
-	available := maxNameLen - len(fp) - 1
+	available := maxLabelValueLen - len(fp) - 1
 	return truncateDNS(name, available) + "-" + fp
 }
 

--- a/internal/proposal/build_test.go
+++ b/internal/proposal/build_test.go
@@ -296,18 +296,25 @@ func TestBuildName(t *testing.T) {
 			expected:    "alert-with-special-chars-my-ns--aabbccdd",
 		},
 		{
+			name:        "long name truncated to 63 chars with namespace",
+			alertName:   "AlertmanagerReceiversNotConfigured",
+			namespace:   "openshift-monitoring",
+			fingerprint: "72bc0ebbaa112233",
+			expected:    "alertmanagerreceiversnotconfigure-openshift-monitoring-72bc0ebb",
+		},
+		{
 			name:        "long alert name truncated with namespace",
 			alertName:   strings.Repeat("a", 250),
 			namespace:   "ns",
 			fingerprint: "12345678",
-			expected:    strings.Repeat("a", 253-len("-ns-12345678")) + "-ns-12345678",
+			expected:    strings.Repeat("a", maxLabelValueLen-len("-ns-12345678")) + "-ns-12345678",
 		},
 		{
 			name:        "long alert name truncated without namespace",
 			alertName:   strings.Repeat("a", 250),
 			namespace:   "",
 			fingerprint: "12345678",
-			expected:    strings.Repeat("a", 253-len("-12345678")) + "-12345678",
+			expected:    strings.Repeat("a", maxLabelValueLen-len("-12345678")) + "-12345678",
 		},
 	}
 
@@ -317,8 +324,8 @@ func TestBuildName(t *testing.T) {
 			if got != tt.expected {
 				t.Errorf("buildName() = %q, want %q", got, tt.expected)
 			}
-			if len(got) > maxNameLen {
-				t.Errorf("name length %d exceeds max %d", len(got), maxNameLen)
+			if len(got) > maxLabelValueLen {
+				t.Errorf("name length %d exceeds max %d", len(got), maxLabelValueLen)
 			}
 		})
 	}

--- a/openspec/specs/proposal-building/spec.md
+++ b/openspec/specs/proposal-building/spec.md
@@ -24,9 +24,9 @@ The system SHALL sanitize alert values to conform to Kubernetes naming and label
 - **WHEN** the alertname or namespace contains characters not allowed in DNS subdomain names
 - **THEN** those characters are replaced with hyphens and the result is lowercased
 
-#### Scenario: Proposal name exceeds 253 characters
-- **WHEN** the computed name would exceed 253 characters
-- **THEN** the alertname component is truncated to fit within the limit while preserving the namespace and fingerprint suffix
+#### Scenario: Proposal name exceeds 63 characters
+- **WHEN** the computed name would exceed 63 characters (the Kubernetes label value limit, since the agentic operator uses the Proposal name as a label value)
+- **THEN** the alertname component is truncated to fit within the 63-character limit while preserving the namespace and fingerprint suffix
 
 #### Scenario: Label value exceeds 63 characters
 - **WHEN** an alert field used as a label value exceeds 63 characters


### PR DESCRIPTION
The agentic operator uses the Proposal name as a Kubernetes label value, which has a 63-byte limit. Names like
"alertmanagerreceiversnotconfigured-openshift-monitoring-72bc0ebb" (69 chars) caused the operator to fail creating the analysis pod.

Change buildName to truncate at maxLabelValueLen (63) instead of maxNameLen (253), always preserving the fingerprint suffix. Remove the now-unused maxNameLen constant.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Proposal name length constraints to comply with Kubernetes label value limits. Proposal names are now capped at 63 characters and are truncated appropriately to preserve essential identifier components while meeting this constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->