### PR TITLE
fix: update the manifest files

### DIFF
--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -19,6 +19,8 @@ data:
     # same alert fingerprint. Prevents flooding for flapping alerts.
     # Default: 1h
     cooldownWindow: 1h
+    allowedReceivers:
+     - critical
 
     # tools: shared skills for all workflow steps (maps to spec.tools on the Proposal).
     # When configured, every Proposal created by the adapter includes these skills.

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: adapter
-          image: quay.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter:latest
+          image: quay.io/openshiftanalytics/lightspeed-agentic-alerts-adapter:latest
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The adapter now only accepts `critical` as an allowed receiver value, preventing unsupported receiver settings from being used.
* **Chores**
  * Updated the adapter container image used by the deployment to the latest published image from the new registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->