### PR TITLE
refactor: load config from mounted file instead of k8s API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,7 +100,7 @@ every <pollInterval> (default 30s):
         f. Else → CREATE Proposal
 ```
 
-**Poll interval**: 30 seconds by default, configurable via ConfigMap. The initial delay dominates response latency, so the poll interval doesn't need to be aggressive.
+**Poll interval**: 30 seconds by default, configurable via ConfigMap. The poll interval is fixed for the lifetime of the process; changes require a pod restart (triggered by the operator). The initial delay dominates response latency, so the poll interval doesn't need to be aggressive.
 
 The query parameters ensure the adapter only processes alerts that are actively firing and not suppressed by AlertManager's silencing or inhibition rules.
 
@@ -270,9 +270,17 @@ spec:
         app: lightspeed-agentic-alerts-adapter
     spec:
       serviceAccountName: lightspeed-agentic-alerts-adapter
+      volumes:
+        - name: config
+          configMap:
+            name: alerts-adapter-config
       containers:
         - name: adapter
           image: quay.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter:latest
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alerts-adapter
+              readOnly: true
           env:
             - name: ALERTMANAGER_URL
               value: https://alertmanager-main.openshift-monitoring.svc:9094
@@ -345,11 +353,11 @@ subjects:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ALERTMANAGER_URL` | `https://alertmanager-main.openshift-monitoring.svc:9094` | AlertManager API endpoint |
-| `POD_NAMESPACE` | `openshift-lightspeed` | Namespace for ConfigMap lookup (set via downward API in the deployment manifest) |
+| `POD_NAMESPACE` | `openshift-lightspeed` | Adapter's namespace (set via downward API in the deployment manifest) |
 
 ### ConfigMap
 
-Runtime-tunable parameters are read from the `alerts-adapter-config` ConfigMap (key: `config.yaml`) in the adapter's namespace on every poll cycle. Changes take effect on the next cycle — no restart required. If the ConfigMap is missing or malformed, defaults are used.
+The `alerts-adapter-config` ConfigMap is mounted as a volume at `/etc/alerts-adapter/` and read once at startup from the `config.yaml` key. If the file is missing or malformed, defaults are used. The operator watches the ConfigMap and restarts the adapter pod when the config changes.
 
 | Field | Default | Description |
 |-------|---------|-------------|

--- a/cmd/alerts-adapter/main.go
+++ b/cmd/alerts-adapter/main.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +28,8 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
+	cfg := config.LoadFromFile(config.DefaultConfigPath, logger)
+
 	amClient, err := alertmanager.New(alertmanager.Config{
 		URL: os.Getenv("ALERTMANAGER_URL"),
 	})
@@ -44,9 +45,8 @@ func main() {
 	}
 
 	propClient := proposal.NewClient(k8sClient, logger)
-	cfgSource := config.NewConfigMapSource(k8sClient, os.Getenv("POD_NAMESPACE"), logger)
 
-	a := adapter.New(amClient, propClient, cfgSource, logger)
+	a := adapter.New(amClient, propClient, cfg, logger)
 	if err := a.Run(ctx); err != nil {
 		logger.Error("fatal error", "error", err)
 		os.Exit(1)
@@ -55,9 +55,6 @@ func main() {
 
 func newClient() (client.Client, error) {
 	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		return nil, fmt.Errorf("registering core scheme: %w", err)
-	}
 	if err := agenticv1alpha1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("registering agentic scheme: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/openshift/lightspeed-agentic-operator/api v0.0.1-dev.20260520
 	github.com/prometheus/alertmanager v0.32.1
 	go.yaml.in/yaml/v3 v3.0.4
-	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.36.1
 	sigs.k8s.io/controller-runtime v0.23.3
 )
@@ -75,6 +74,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/api v0.35.3 // indirect
 	k8s.io/apiextensions-apiserver v0.35.3 // indirect
 	k8s.io/client-go v0.35.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -28,46 +28,39 @@ type ProposalClient interface {
 	CreateProposal(ctx context.Context, p *agenticv1alpha1.Proposal) (bool, error)
 }
 
-// ConfigSource provides runtime configuration for each poll cycle.
-type ConfigSource interface {
-	Load(ctx context.Context) config.Config
-}
-
 // Adapter polls AlertManager for firing alerts and creates Proposal CRs,
 // applying stateless deduplication (initial delay, active-proposal check,
 // and cooldown window) on each cycle.
 type Adapter struct {
 	alerts    AlertSource
 	proposals ProposalClient
-	config    ConfigSource
+	cfg       config.Config
 	logger    *slog.Logger
 }
 
 // New creates an Adapter with the given alert source, proposal client,
-// config source, and logger.
-func New(alerts AlertSource, proposals ProposalClient, cfg ConfigSource, logger *slog.Logger) *Adapter {
+// config, and logger.
+func New(alerts AlertSource, proposals ProposalClient, cfg config.Config, logger *slog.Logger) *Adapter {
 	return &Adapter{
 		alerts:    alerts,
 		proposals: proposals,
-		config:    cfg,
+		cfg:       cfg,
 		logger:    logger,
 	}
 }
 
 // Run starts the poll loop, blocking until the context is cancelled.
 func (a *Adapter) Run(ctx context.Context) error {
-	cfg := a.config.Load(ctx)
 	a.logger.Info("adapter started",
-		"pollInterval", cfg.PollInterval,
-		"initialDelay", cfg.InitialDelay,
-		"cooldownWindow", cfg.CooldownWindow,
-		"allowedReceivers", cfg.AllowedReceivers,
+		"pollInterval", a.cfg.PollInterval,
+		"initialDelay", a.cfg.InitialDelay,
+		"cooldownWindow", a.cfg.CooldownWindow,
+		"allowedReceivers", a.cfg.AllowedReceivers,
 	)
 
 	a.reconcile(ctx)
 
-	currentInterval := cfg.PollInterval
-	ticker := time.NewTicker(currentInterval)
+	ticker := time.NewTicker(a.cfg.PollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -77,28 +70,12 @@ func (a *Adapter) Run(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			a.reconcile(ctx)
-
-			newCfg := a.config.Load(ctx)
-			if !configEqual(cfg, newCfg) {
-				a.logger.Info("config reloaded",
-					"pollInterval", newCfg.PollInterval,
-					"initialDelay", newCfg.InitialDelay,
-					"cooldownWindow", newCfg.CooldownWindow,
-					"allowedReceivers", newCfg.AllowedReceivers,
-				)
-				if newCfg.PollInterval != cfg.PollInterval {
-					ticker.Reset(newCfg.PollInterval)
-				}
-				cfg = newCfg
-			}
 		}
 	}
 }
 
 func (a *Adapter) reconcile(ctx context.Context) {
 	a.logger.Debug("poll cycle start")
-
-	cfg := a.config.Load(ctx)
 
 	alerts, err := a.alerts.GetAlerts(ctx)
 	if err != nil {
@@ -128,7 +105,7 @@ func (a *Adapter) reconcile(ctx context.Context) {
 		}
 		alertName := alert.Labels["alertname"]
 
-		if skipReceiver(alert, cfg.AllowedReceivers) {
+		if skipReceiver(alert, a.cfg.AllowedReceivers) {
 			a.logger.Debug("alert skipped: no matching receiver",
 				"alertname", alertName,
 				"fingerprint", fingerprint,
@@ -148,12 +125,12 @@ func (a *Adapter) reconcile(ctx context.Context) {
 			continue
 		}
 
-		if skipInitialDelay(alert, now, cfg.InitialDelay) {
+		if skipInitialDelay(alert, now, a.cfg.InitialDelay) {
 			a.logger.Debug("alert skipped: initial delay",
 				"alertname", alertName,
 				"fingerprint", fingerprint,
 				"startsAt", alert.StartsAt,
-				"threshold", cfg.InitialDelay,
+				"threshold", a.cfg.InitialDelay,
 			)
 			skipped++
 			continue
@@ -168,17 +145,17 @@ func (a *Adapter) reconcile(ctx context.Context) {
 			continue
 		}
 
-		if inCooldown(alert, proposals, now, cfg.CooldownWindow) {
+		if inCooldown(alert, proposals, now, a.cfg.CooldownWindow) {
 			a.logger.Debug("alert skipped: cooldown window",
 				"alertname", alertName,
 				"fingerprint", fingerprint,
-				"cooldown", cfg.CooldownWindow,
+				"cooldown", a.cfg.CooldownWindow,
 			)
 			skipped++
 			continue
 		}
 
-		p, err := proposal.Build(alert, cfg.Tools)
+		p, err := proposal.Build(alert, a.cfg.Tools)
 		if err != nil {
 			a.logger.Error("failed to build proposal",
 				"alertname", alertName,
@@ -336,13 +313,6 @@ func isTerminal(phase agenticv1alpha1.ProposalPhase) bool {
 		return true
 	}
 	return false
-}
-
-func configEqual(a, b config.Config) bool {
-	return a.PollInterval == b.PollInterval &&
-		a.InitialDelay == b.InitialDelay &&
-		a.CooldownWindow == b.CooldownWindow &&
-		slices.Equal(a.AllowedReceivers, b.AllowedReceivers)
 }
 
 func fingerprintPrefix(alert *models.GettableAlert) string {

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -50,19 +50,20 @@ func (f *fakeProposalClient) CreateProposal(_ context.Context, p *agenticv1alpha
 	return true, nil
 }
 
-type staticConfigSource struct {
-	cfg config.Config
-}
-
-func (s *staticConfigSource) Load(_ context.Context) config.Config {
-	return s.cfg
-}
-
 func quietLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func ptr[T any](v T) *T { return &v }
+
+func defaultTestConfig() config.Config {
+	return config.Config{
+		PollInterval:     config.DefaultPollInterval,
+		InitialDelay:     config.DefaultInitialDelay,
+		CooldownWindow:   config.DefaultCooldownWindow,
+		AllowedReceivers: []string{"critical"},
+	}
+}
 
 func makeAlert(name, fingerprint string, startsAt time.Time) *models.GettableAlert {
 	return makeAlertWithSeverity(name, fingerprint, startsAt, "warning")
@@ -280,12 +281,7 @@ func TestReconcile(t *testing.T) {
 			a := &Adapter{
 				alerts:    as,
 				proposals: pc,
-				config: &staticConfigSource{cfg: config.Config{
-					PollInterval:     config.DefaultPollInterval,
-					InitialDelay:     config.DefaultInitialDelay,
-					CooldownWindow:   config.DefaultCooldownWindow,
-					AllowedReceivers: []string{"critical"},
-				}},
+				cfg:       defaultTestConfig(),
 				logger:    quietLogger(),
 			}
 
@@ -452,12 +448,7 @@ func TestReconcileSkipsSeverity(t *testing.T) {
 			a := &Adapter{
 				alerts:    as,
 				proposals: pc,
-				config: &staticConfigSource{cfg: config.Config{
-					PollInterval:     config.DefaultPollInterval,
-					InitialDelay:     config.DefaultInitialDelay,
-					CooldownWindow:   config.DefaultCooldownWindow,
-					AllowedReceivers: []string{"critical"},
-				}},
+				cfg:       defaultTestConfig(),
 				logger:    quietLogger(),
 			}
 
@@ -487,7 +478,7 @@ func TestReconcileWithTools(t *testing.T) {
 		a := &Adapter{
 			alerts:    as,
 			proposals: pc,
-			config:    &staticConfigSource{cfg: cfg},
+			cfg:       cfg,
 			logger:    quietLogger(),
 		}
 
@@ -521,7 +512,7 @@ func TestReconcileWithTools(t *testing.T) {
 		a := &Adapter{
 			alerts:    as,
 			proposals: pc,
-			config:    &staticConfigSource{cfg: cfg},
+			cfg:       cfg,
 			logger:    quietLogger(),
 		}
 
@@ -556,16 +547,14 @@ func TestRunExitsOnContextCancel(t *testing.T) {
 	as := &fakeAlertSource{}
 	pc := &fakeProposalClient{}
 
+	cfg := defaultTestConfig()
+	cfg.PollInterval = time.Hour
+
 	a := &Adapter{
 		alerts:    as,
 		proposals: pc,
-		config: &staticConfigSource{cfg: config.Config{
-			PollInterval:     time.Hour,
-			InitialDelay:     config.DefaultInitialDelay,
-			CooldownWindow:   config.DefaultCooldownWindow,
-			AllowedReceivers: []string{"critical"},
-		}},
-		logger: quietLogger(),
+		cfg:       cfg,
+		logger:    quietLogger(),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -9,10 +8,6 @@ import (
 	"time"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -21,9 +16,7 @@ const (
 	DefaultInitialDelay   = 5 * time.Minute
 	DefaultCooldownWindow = 1 * time.Hour
 
-	configMapName    = "alerts-adapter-config"
-	configMapDataKey = "config.yaml"
-	defaultNamespace = "openshift-lightspeed"
+	DefaultConfigPath = "/etc/alerts-adapter/config.yaml"
 )
 
 // ToolsConfig holds shared and per-step skills configuration.
@@ -97,55 +90,20 @@ func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-// ConfigMapSource reads configuration from a Kubernetes ConfigMap.
-type ConfigMapSource struct {
-	client    client.Reader
-	namespace string
-	logger    *slog.Logger
-}
-
-// NewConfigMapSource creates a ConfigMapSource that reads the alerts-adapter-config
-// ConfigMap from the given namespace. If namespace is empty, it reads POD_NAMESPACE
-// from the environment, falling back to openshift-lightspeed.
-func NewConfigMapSource(c client.Reader, namespace string, logger *slog.Logger) *ConfigMapSource {
-	if namespace == "" {
-		namespace = os.Getenv("POD_NAMESPACE")
-	}
-	if namespace == "" {
-		namespace = defaultNamespace
-	}
-	return &ConfigMapSource{
-		client:    c,
-		namespace: namespace,
-		logger:    logger,
-	}
-}
-
-// Load reads the ConfigMap and returns the current configuration.
-// It never returns an error — on any failure it falls back to defaults.
-func (s *ConfigMapSource) Load(ctx context.Context) Config {
+// LoadFromFile reads configuration from a YAML file at the given path.
+// It never returns an error — on any failure it falls back to defaults and logs.
+func LoadFromFile(path string, logger *slog.Logger) Config {
 	cfg := Default()
 
-	var cm corev1.ConfigMap
-	key := types.NamespacedName{Name: configMapName, Namespace: s.namespace}
-	if err := s.client.Get(ctx, key, &cm); err != nil {
-		if apierrors.IsNotFound(err) {
-			s.logger.Info("config ConfigMap not found, using defaults", "name", configMapName, "namespace", s.namespace)
-		} else {
-			s.logger.Warn("failed to read config ConfigMap, using defaults", "error", err)
-		}
-		return cfg
-	}
-
-	data, ok := cm.Data[configMapDataKey]
-	if !ok {
-		s.logger.Info("config ConfigMap missing config.yaml key, using defaults", "name", configMapName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		logger.Error("failed to read config file, using defaults", "path", path, "error", err)
 		return cfg
 	}
 
 	var cf configFile
-	if err := yaml.Unmarshal([]byte(data), &cf); err != nil {
-		s.logger.Warn("failed to parse config.yaml, using defaults", "error", err)
+	if err := yaml.Unmarshal(data, &cf); err != nil {
+		logger.Error("failed to parse config file, using defaults", "path", path, "error", err)
 		return cfg
 	}
 
@@ -153,21 +111,21 @@ func (s *ConfigMapSource) Load(ctx context.Context) Config {
 		if cf.PollInterval.Duration > 0 {
 			cfg.PollInterval = cf.PollInterval.Duration
 		} else {
-			s.logger.Warn("pollInterval must be positive, using default", "value", cf.PollInterval.Duration)
+			logger.Error("pollInterval must be positive, using default", "value", cf.PollInterval.Duration)
 		}
 	}
 	if cf.InitialDelay.isSet {
 		if cf.InitialDelay.Duration > 0 {
 			cfg.InitialDelay = cf.InitialDelay.Duration
 		} else {
-			s.logger.Warn("initialDelay must be positive, using default", "value", cf.InitialDelay.Duration)
+			logger.Error("initialDelay must be positive, using default", "value", cf.InitialDelay.Duration)
 		}
 	}
 	if cf.CooldownWindow.isSet {
 		if cf.CooldownWindow.Duration > 0 {
 			cfg.CooldownWindow = cf.CooldownWindow.Duration
 		} else {
-			s.logger.Warn("cooldownWindow must be positive, using default", "value", cf.CooldownWindow.Duration)
+			logger.Error("cooldownWindow must be positive, using default", "value", cf.CooldownWindow.Duration)
 		}
 	}
 
@@ -180,24 +138,24 @@ func (s *ConfigMapSource) Load(ctx context.Context) Config {
 	}
 
 	cfg.Tools = ToolsConfig{
-		Shared:       s.parseSkills(cf.Tools.Skills, "shared"),
-		Analysis:     s.parseSkills(cf.Analysis.Tools.Skills, "analysis"),
-		Execution:    s.parseSkills(cf.Execution.Tools.Skills, "execution"),
-		Verification: s.parseSkills(cf.Verification.Tools.Skills, "verification"),
+		Shared:       parseSkills(cf.Tools.Skills, "shared", logger),
+		Analysis:     parseSkills(cf.Analysis.Tools.Skills, "analysis", logger),
+		Execution:    parseSkills(cf.Execution.Tools.Skills, "execution", logger),
+		Verification: parseSkills(cf.Verification.Tools.Skills, "verification", logger),
 	}
 
 	return cfg
 }
 
-func (s *ConfigMapSource) parseSkills(entries []skillsEntry, step string) []agenticv1alpha1.SkillsSource {
+func parseSkills(entries []skillsEntry, step string, logger *slog.Logger) []agenticv1alpha1.SkillsSource {
 	var skills []agenticv1alpha1.SkillsSource
 	for _, e := range entries {
 		if e.Image == "" {
-			s.logger.Warn("skills entry missing image, skipping", "step", step)
+			logger.Warn("skills entry missing image, skipping", "step", step)
 			continue
 		}
 		if len(e.Paths) == 0 {
-			s.logger.Warn("skills entry missing paths, skipping", "step", step)
+			logger.Warn("skills entry missing paths, skipping", "step", step)
 			continue
 		}
 		skills = append(skills, agenticv1alpha1.SkillsSource{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,24 +1,31 @@
 package config
 
 import (
-	"context"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func quietLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func TestParseConfigFile(t *testing.T) {
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	return path
+}
+
+func TestLoadFromFile(t *testing.T) {
 	tests := []struct {
 		name               string
 		yaml               string
@@ -65,10 +72,9 @@ func TestParseConfigFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm := configMapWith(tt.yaml)
-			src := newTestSource(t, cm)
+			path := writeConfigFile(t, tt.yaml)
 
-			cfg := src.Load(context.Background())
+			cfg := LoadFromFile(path, quietLogger())
 
 			if cfg.PollInterval != tt.wantPollInterval {
 				t.Errorf("PollInterval = %v, want %v", cfg.PollInterval, tt.wantPollInterval)
@@ -83,7 +89,7 @@ func TestParseConfigFile(t *testing.T) {
 	}
 }
 
-func TestParseConfigFileInvalid(t *testing.T) {
+func TestLoadFromFileInvalid(t *testing.T) {
 	tests := []struct {
 		name string
 		yaml string
@@ -100,10 +106,9 @@ func TestParseConfigFileInvalid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm := configMapWith(tt.yaml)
-			src := newTestSource(t, cm)
+			path := writeConfigFile(t, tt.yaml)
 
-			cfg := src.Load(context.Background())
+			cfg := LoadFromFile(path, quietLogger())
 
 			assertDefaults(t, cfg)
 		})
@@ -135,75 +140,19 @@ func TestNonPositiveDurationsFallBackToDefaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm := configMapWith(tt.yaml)
-			src := newTestSource(t, cm)
+			path := writeConfigFile(t, tt.yaml)
 
-			cfg := src.Load(context.Background())
+			cfg := LoadFromFile(path, quietLogger())
 
 			assertDefaults(t, cfg)
 		})
 	}
 }
 
-func TestLoadConfigMapNotFound(t *testing.T) {
-	src := newTestSource(t)
-
-	cfg := src.Load(context.Background())
+func TestLoadFromFileMissing(t *testing.T) {
+	cfg := LoadFromFile("/nonexistent/path/config.yaml", quietLogger())
 
 	assertDefaults(t, cfg)
-}
-
-func TestLoadConfigMapMissingKey(t *testing.T) {
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: defaultNamespace,
-		},
-		Data: map[string]string{
-			"other-key": "value",
-		},
-	}
-	src := newTestSource(t, cm)
-
-	cfg := src.Load(context.Background())
-
-	assertDefaults(t, cfg)
-}
-
-func TestLoadConfigMapEmptyData(t *testing.T) {
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: defaultNamespace,
-		},
-	}
-	src := newTestSource(t, cm)
-
-	cfg := src.Load(context.Background())
-
-	assertDefaults(t, cfg)
-}
-
-func configMapWith(yamlData string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: defaultNamespace,
-		},
-		Data: map[string]string{
-			configMapDataKey: yamlData,
-		},
-	}
-}
-
-func newTestSource(t *testing.T, objs ...runtime.Object) *ConfigMapSource {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("failed to add corev1 to scheme: %v", err)
-	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
-	return NewConfigMapSource(c, defaultNamespace, quietLogger())
 }
 
 func assertDefaults(t *testing.T, cfg Config) {
@@ -405,10 +354,9 @@ execution:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm := configMapWith(tt.yaml)
-			src := newTestSource(t, cm)
+			path := writeConfigFile(t, tt.yaml)
 
-			cfg := src.Load(context.Background())
+			cfg := LoadFromFile(path, quietLogger())
 
 			assertSkillsEqual(t, "Tools.Shared", cfg.Tools.Shared, tt.wantTools.Shared)
 			assertSkillsEqual(t, "Tools.Analysis", cfg.Tools.Analysis, tt.wantTools.Analysis)
@@ -453,20 +401,17 @@ func TestParseAllowedReceivers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm := configMapWith(tt.yaml)
-			src := newTestSource(t, cm)
+			path := writeConfigFile(t, tt.yaml)
 
-			cfg := src.Load(context.Background())
+			cfg := LoadFromFile(path, quietLogger())
 
 			assertReceiversEqual(t, cfg.AllowedReceivers, tt.want)
 		})
 	}
 }
 
-func TestAllowedReceiversDefaultsOnMissingConfigMap(t *testing.T) {
-	src := newTestSource(t)
-
-	cfg := src.Load(context.Background())
+func TestAllowedReceiversDefaultsOnMissingFile(t *testing.T) {
+	cfg := LoadFromFile("/nonexistent/path/config.yaml", quietLogger())
 
 	assertReceiversEqual(t, cfg.AllowedReceivers, nil)
 }

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       serviceAccountName: lightspeed-agentic-alerts-adapter
       securityContext:
         runAsNonRoot: true
+      volumes:
+        - name: config
+          configMap:
+            name: alerts-adapter-config
       containers:
         - name: adapter
           image: quay.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter:latest
@@ -25,6 +29,10 @@ spec:
             capabilities:
               drop:
                 - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alerts-adapter
+              readOnly: true
           env:
             - name: ALERTMANAGER_URL
               value: https://alertmanager-main.openshift-monitoring.svc:9094

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -21,32 +21,6 @@ subjects:
     name: lightspeed-agentic-alerts-adapter
     namespace: openshift-lightspeed
 ---
-# Config: read the alerts-adapter-config ConfigMap for runtime settings.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: lightspeed-agentic-alerts-adapter-config
-  namespace: openshift-lightspeed
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    resourceNames: ["alerts-adapter-config"]
-    verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: lightspeed-agentic-alerts-adapter-config
-  namespace: openshift-lightspeed
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: lightspeed-agentic-alerts-adapter-config
-subjects:
-  - kind: ServiceAccount
-    name: lightspeed-agentic-alerts-adapter
-    namespace: openshift-lightspeed
----
 # AlertManager: read firing alerts from the monitoring stack.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/openspec/changes/configmap-mounted/.openspec.yaml
+++ b/openspec/changes/configmap-mounted/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/configmap-mounted/design.md
+++ b/openspec/changes/configmap-mounted/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The adapter currently uses a `ConfigMapSource` that calls the Kubernetes API (`client.Get`) to read the `alerts-adapter-config` ConfigMap on every reconcile cycle. This works but generates one API call per poll interval (every 30s by default). The `Run` loop includes logic to detect config changes between cycles, reset the ticker if `pollInterval` changed, and log reloads.
+
+The operator that deploys the adapter already manages the Deployment resource. Kubernetes natively supports mounting ConfigMaps as volumes and the operator can watch the ConfigMap to trigger a rolling restart when it changes. This moves config-change detection from the adapter to the platform.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the Kubernetes API-based config reader with a file-based reader that loads config once at startup.
+- Simplify the poll loop by removing per-cycle config reload, `configEqual`, and dynamic ticker reset.
+- Mount the ConfigMap as a volume in the Deployment manifest.
+- Remove ConfigMap RBAC (the adapter no longer queries the API for ConfigMaps).
+- Preserve all existing fallback-to-defaults behavior (missing file, invalid YAML, non-positive durations).
+
+**Non-Goals:**
+- Implementing the operator-side ConfigMap watch and pod restart — that belongs in the `lightspeed-agentic-operator` repo.
+- Changing the ConfigMap YAML schema or config field semantics.
+- Adding a file-watcher or hot-reload capability to the adapter.
+
+## Decisions
+
+### 1. Load-once file-based config replaces `ConfigMapSource` and `ConfigSource` interface
+
+Replace `ConfigMapSource` with a `LoadFromFile(path string, logger *slog.Logger) Config` function. It reads the file at the given path, parses YAML, applies defaults — same logic as today minus the Kubernetes API call. If reading or parsing the file fails for any reason (missing file, invalid YAML, non-positive durations), the function falls back to default values and logs an error. The adapter always starts. `adapter.New` accepts `config.Config` directly instead of a `ConfigSource` interface. The `Run` loop and `reconcile` use this fixed config.
+
+**Rationale:** The `ConfigSource` interface and per-cycle `Load` call only existed to support dynamic config reload. With load-once semantics, a plain function called in `main.go` is simpler — it eliminates the interface, `configEqual`, the ticker-reset branch, and the per-cycle `Load` call in `reconcile`.
+
+**Alternative considered:** Keep the `ConfigSource` interface with a `FileSource` struct that caches the result. Rejected — unnecessary abstraction when the adapter is restarted on config change.
+
+### 2. Hardcoded config file path with volume mount
+
+The adapter reads config from `/etc/alerts-adapter/config.yaml`. The ConfigMap is mounted at `/etc/alerts-adapter/` in the Deployment manifest. No environment variable is needed — the operator programmatically creates the Deployment and controls the mount path.
+
+**Rationale:** The path is a contract between the operator and the adapter, both maintained by the same team. An env var would add indirection with no benefit since the operator always sets both the mount and the path.
+
+### 3. Remove ConfigMap RBAC
+
+The `Role` and `RoleBinding` for ConfigMap `get` access are deleted from `manifests/rbac.yaml`.
+
+**Rationale:** The adapter no longer makes API calls to read ConfigMaps. Least-privilege principle — don't request permissions you don't use.
+
+### 4. Remove `corev1` scheme registration from `main.go`
+
+With no ConfigMap API calls, `corev1.AddToScheme` is no longer needed in `main.go`.
+
+**Rationale:** The `corev1` scheme was only registered to support the `client.Get` call for the ConfigMap. Proposal CRs use only the `agenticv1alpha1` scheme.
+
+## Risks / Trade-offs
+
+- **Config changes require pod restart** → Mitigated by the operator watching the ConfigMap and triggering a rolling restart. Until the operator implements this, config changes require a manual pod restart.
+- **Startup failure on missing config file** → Mitigated by treating a missing file as "use defaults" and logging an error, same as today's missing-ConfigMap behavior. The adapter always starts.
+- **Loss of dynamic poll-interval tuning** → Accepted trade-off. The previous per-cycle reload allowed changing `pollInterval` without a restart. With the new model, changes take effect after the operator-triggered restart (seconds, not cycles). This is acceptable for a 30s default interval.

--- a/openspec/changes/configmap-mounted/proposal.md
+++ b/openspec/changes/configmap-mounted/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The adapter currently reads the `alerts-adapter-config` ConfigMap via the Kubernetes API on every poll cycle (every 30s by default). This creates unnecessary API server load and couples the adapter to ConfigMap RBAC (`get` verb) at runtime. Since the operator already deploys the adapter, it can mount the ConfigMap as a volume and watch for changes — restarting the pod when the config changes. This simplifies the adapter to a read-once-at-startup model, reduces API calls, and removes the need for dynamic config-reload logic inside the adapter.
+
+## What Changes
+
+- The adapter reads configuration from a local file (mounted ConfigMap volume) at startup instead of calling the Kubernetes API each cycle.
+- The `ConfigSource` interface and `ConfigMapSource` implementation are replaced with a file-based config loader.
+- The poll loop no longer reloads config on each cycle — it uses the config loaded at startup for its entire lifetime.
+- The `configEqual` function and dynamic ticker-reset logic in the `Run` loop are removed.
+- The deployment manifest gains a ConfigMap volume mount.
+- The ConfigMap RBAC (`Role` + `RoleBinding` for `get` on configmaps) is removed — the adapter no longer needs Kubernetes API access to ConfigMaps.
+- **Note:** The operator-side watch + restart logic is out of scope for this repo — it is the operator's responsibility.
+
+## Capabilities
+
+### New Capabilities
+- `file-config`: Loading configuration from a file path at startup, replacing the Kubernetes API-based ConfigMap reader.
+
+### Modified Capabilities
+- `configmap-config`: Requirements change from "load each reconcile cycle" to "load once at startup from a mounted file". Fallback-to-defaults behavior is preserved but triggered only at startup.
+- `poll-loop`: Requirements change to remove per-cycle config reload and dynamic poll-interval adjustment.
+
+## Impact
+
+- **`internal/config/`** — `ConfigMapSource` and its Kubernetes client dependency are removed. A new file-based loader replaces it. The `Config`, `ToolsConfig`, and YAML parsing types are retained.
+- **`internal/adapter/`** — `ConfigSource` interface simplified (no `context.Context` needed). `Run` loop simplified: no per-cycle `Load`, no `configEqual`, no ticker reset. `reconcile` receives config as a parameter instead of loading it.
+- **`cmd/alerts-adapter/main.go`** — No longer needs `corev1` scheme or `controller-runtime` client for config. Reads a config file path from an environment variable or flag.
+- **`manifests/deployment.yaml`** — Adds ConfigMap volume and volumeMount.
+- **`manifests/rbac.yaml`** — Removes the `Role`/`RoleBinding` for ConfigMap access.
+- **Dependencies** — `k8s.io/api/core/v1` and `sigs.k8s.io/controller-runtime/pkg/client` may become unused if Proposals also stop needing them (Proposals still need the client, so `controller-runtime` stays but `corev1` registration in `main.go` can be removed).

--- a/openspec/changes/configmap-mounted/specs/configmap-config/spec.md
+++ b/openspec/changes/configmap-mounted/specs/configmap-config/spec.md
@@ -1,0 +1,17 @@
+## REMOVED Requirements
+
+### Requirement: Load configuration from a ConfigMap each reconcile cycle
+**Reason**: Replaced by file-based config loading at startup. The ConfigMap is now mounted as a volume by the operator, and the adapter reads the resulting file once at startup instead of querying the Kubernetes API each cycle.
+**Migration**: Configuration is still provided via the same `alerts-adapter-config` ConfigMap, but it is now consumed as a mounted file rather than via API calls. The operator watches the ConfigMap and restarts the adapter on changes.
+
+### Requirement: Operate normally when ConfigMap does not exist
+**Reason**: Replaced by equivalent behavior in the `file-config` capability. The adapter falls back to defaults when the mounted config file does not exist.
+**Migration**: No action needed — the fallback-to-defaults behavior is preserved in the file-based loader.
+
+### Requirement: Use well-defined default values
+**Reason**: Moved to the `file-config` capability with identical default values.
+**Migration**: No action needed — same defaults apply.
+
+### Requirement: Resolve the adapter namespace from the environment
+**Reason**: The adapter no longer reads ConfigMaps via the Kubernetes API, so the namespace is irrelevant. The config file path is hardcoded.
+**Migration**: The `POD_NAMESPACE` environment variable is no longer used for config loading. It may still be used for other purposes (e.g., Proposal creation namespace).

--- a/openspec/changes/configmap-mounted/specs/file-config/spec.md
+++ b/openspec/changes/configmap-mounted/specs/file-config/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Load configuration from a file at startup
+The system SHALL read configuration from a YAML file at the path `/etc/alerts-adapter/config.yaml` once at startup and use the resulting values for the entire lifetime of the process.
+
+#### Scenario: Config file exists with valid YAML
+- **WHEN** the file at `/etc/alerts-adapter/config.yaml` exists and contains valid YAML with valid duration values
+- **THEN** the system uses the values from the file
+
+#### Scenario: Config file exists with partial YAML
+- **WHEN** the file exists and contains valid YAML with only some fields specified
+- **THEN** the system uses the specified values and falls back to defaults for missing fields
+
+#### Scenario: Config file exists with invalid duration value
+- **WHEN** the file exists and contains an unparseable duration string for one or more fields
+- **THEN** the system falls back to the default value for each invalid field and logs an error for each invalid field
+
+#### Scenario: Config file exists with non-positive duration value
+- **WHEN** the file exists and contains a zero or negative duration (e.g., `pollInterval: 0s` or `initialDelay: -1m`)
+- **THEN** the system falls back to the default value for each non-positive field and logs an error for each non-positive field
+
+#### Scenario: Config file exists with invalid YAML
+- **WHEN** the file exists and contains content that is not valid YAML
+- **THEN** the system falls back to all default values and logs an error
+
+#### Scenario: Config file does not exist
+- **WHEN** the file at `/etc/alerts-adapter/config.yaml` does not exist
+- **THEN** the system falls back to all default values and logs an error
+
+### Requirement: Use well-defined default values
+The system SHALL use the following default values when the config file is missing, unreadable, or when individual fields are missing or invalid:
+- `pollInterval`: 30 seconds
+- `initialDelay`: 5 minutes
+- `cooldownWindow`: 1 hour
+- `allowedReceivers`: empty list (no alerts are processed until explicitly configured)
+
+#### Scenario: All defaults applied
+- **WHEN** the config file does not exist or cannot be read
+- **THEN** the system uses `pollInterval=30s`, `initialDelay=5m`, `cooldownWindow=1h`, `allowedReceivers=[]`

--- a/openspec/changes/configmap-mounted/specs/poll-loop/spec.md
+++ b/openspec/changes/configmap-mounted/specs/poll-loop/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Poll AlertManager on a fixed interval
+The system SHALL use the configuration provided at startup for the poll interval and all filtering/deduplication parameters. The poll interval is fixed for the lifetime of the process. The filter order SHALL be: receiver allowlist → severity → initial delay → active proposal → cooldown.
+
+#### Scenario: Normal poll cycle
+- **WHEN** the poll interval elapses
+- **THEN** the system fetches alerts from AlertManager, lists existing Proposals, applies receiver filtering then dedup rules, and creates Proposals for qualifying alerts
+
+#### Scenario: Configuration used from startup
+- **WHEN** a reconcile cycle begins
+- **THEN** the system uses the config values loaded at startup for that cycle's initial delay check, cooldown window check, and receiver filtering
+
+#### Scenario: AlertManager unreachable during poll
+- **WHEN** the AlertManager API returns an error during a poll cycle
+- **THEN** the system logs the error and skips the cycle; the next poll retries
+
+#### Scenario: Kubernetes API unreachable during poll
+- **WHEN** the Kubernetes API returns an error during proposal listing or creation
+- **THEN** the system logs the error and skips the cycle; the next poll retries
+
+## REMOVED Requirements
+
+### Requirement: Poll interval changes between cycles
+**Reason**: The adapter no longer reloads config each cycle. The poll interval is fixed at startup and changes require a pod restart (triggered by the operator).
+**Migration**: Config changes are applied by the operator restarting the adapter pod when the ConfigMap changes.

--- a/openspec/changes/configmap-mounted/tasks.md
+++ b/openspec/changes/configmap-mounted/tasks.md
@@ -1,0 +1,32 @@
+## 1. Config loader
+
+- [x] 1.1 Replace `ConfigMapSource` with `LoadFromFile(path string, logger *slog.Logger) Config` function in `internal/config/config.go` — reads file, parses YAML, falls back to defaults on any error and logs it
+- [x] 1.2 Remove `ConfigMapSource`, `NewConfigMapSource`, and all Kubernetes client imports (`corev1`, `apierrors`, `types`, `client`) from `internal/config/config.go`
+- [x] 1.3 Add the `DefaultConfigPath` constant (`/etc/alerts-adapter/config.yaml`) to `internal/config/config.go`
+- [x] 1.4 Update `internal/config/config_test.go` — replace ConfigMap-based tests with file-based tests covering: valid file, partial YAML, invalid duration, non-positive duration, invalid YAML, missing file
+
+## 2. Adapter simplification
+
+- [x] 2.1 Remove `ConfigSource` interface from `internal/adapter/adapter.go`
+- [x] 2.2 Change `Adapter` struct to hold `config.Config` value instead of `ConfigSource` — update `New` to accept `config.Config`
+- [x] 2.3 Simplify `Run` loop — remove per-cycle `config.Load`, `configEqual`, and dynamic ticker reset
+- [x] 2.4 Simplify `reconcile` — remove the `config.Load` call, use the stored config directly
+- [x] 2.5 Remove the `configEqual` function
+- [x] 2.6 Update `internal/adapter/adapter_test.go` — remove `ConfigSource` mock, pass `config.Config` directly to `New`
+
+## 3. Main wiring
+
+- [x] 3.1 Update `cmd/alerts-adapter/main.go` — call `config.LoadFromFile` at startup, pass the resulting `Config` to `adapter.New`
+- [x] 3.2 Remove `corev1` scheme registration from `newClient` in `main.go`
+- [x] 3.3 Remove the `corev1` import from `main.go`
+
+## 4. Manifests
+
+- [x] 4.1 Add ConfigMap volume and volumeMount to `manifests/deployment.yaml` — mount `alerts-adapter-config` at `/etc/alerts-adapter/`
+- [x] 4.2 Remove the ConfigMap `Role` and `RoleBinding` from `manifests/rbac.yaml`
+
+## 5. Verification
+
+- [x] 5.1 Run `make test` — all tests pass
+- [x] 5.2 Run `make lint` — no lint errors
+- [x] 5.3 Run `make vet` — no vet errors


### PR DESCRIPTION
Replace per-cycle ConfigMap API reads with a file-based config loader that reads once at startup. The ConfigMap is now mounted as a volume by the operator, which watches it and restarts the adapter on changes.

- Replace ConfigMapSource with LoadFromFile function
- Remove ConfigSource interface and per-cycle reload logic
- Remove configEqual and dynamic ticker reset from Run loop
- Add ConfigMap volume mount to deployment manifest
- Remove ConfigMap RBAC (Role + RoleBinding)
- Remove corev1 scheme registration from main.go
- Update ARCHITECTURE.md to reflect new config loading model


Assisted-by: Claude Code:claude-opus-4-6