### PR TITLE
chore: add container-push Makefile target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ make fmt            # go fmt ./...
 make vet            # go vet ./...
 make coverage       # HTML coverage report → coverage.html
 make container-build # podman build
+make container-push  # podman build + push (set IMAGE_NAME, IMAGE_TAG defaults to latest)
 
 # Run a single test
 go test -run TestFunctionName ./internal/adapter/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS ?=
 GOLANGCI_LINT_VERSION ?= v2.12.2
 GOLANGCI_LINT = $(shell which golangci-lint 2>/dev/null)
 
-.PHONY: all build test clean lint fmt vet run coverage container-build help install-lint
+.PHONY: all build test clean lint fmt vet run coverage container-build container-push help install-lint
 
 all: build
 
@@ -48,6 +48,9 @@ coverage:
 container-build:
 	podman build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Containerfile .
 
+container-push: container-build
+	podman push $(IMAGE_NAME):$(IMAGE_TAG)
+
 help:
 	@echo "Targets:"
 	@echo "  build           - Build the binary"
@@ -59,4 +62,5 @@ help:
 	@echo "  run             - Build and run the binary"
 	@echo "  coverage        - Generate test coverage report"
 	@echo "  container-build - Build container image"
+	@echo "  container-push  - Build and push container image (set IMAGE_NAME; IMAGE_TAG defaults to latest)"
 	@echo "  help            - Show this help"

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ make run
 ### Container
 
 ```sh
-make container-build
+make container-build IMAGE_NAME=quay.io/your-org/lightspeed-agentic-alerts-adapter
+make container-push  IMAGE_NAME=quay.io/your-org/lightspeed-agentic-alerts-adapter
 ```
+
+`container-push` depends on `container-build` — it builds and pushes in one step. `IMAGE_TAG` defaults to `latest`.
 
 ### Deploy to OpenShift
 


### PR DESCRIPTION
Add container-push target that depends on container-build, so a single command builds and pushes the image. Update make help, README, and AGENTS.md with usage instructions for IMAGE_NAME and IMAGE_TAG overrides.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for building and pushing container images in one step.
  * Clarified image naming and default tag behavior.
  * Updated the available command list to include the new container push workflow.

* **New Features**
  * Added a new `container-push` command to push container images after building them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->