### PR TITLE
feat: add configurable agent override for Proposal workflow steps

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -155,7 +155,7 @@ func (a *Adapter) reconcile(ctx context.Context) {
 			continue
 		}
 
-		p, err := proposal.Build(alert, a.cfg.Tools)
+		p, err := proposal.Build(alert, a.cfg.Tools, a.cfg.Agent)
 		if err != nil {
 			a.logger.Error("failed to build proposal",
 				"alertname", alertName,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,14 @@ const (
 	DefaultConfigPath = "/etc/alerts-adapter/config.yaml"
 )
 
+// AgentConfig holds the agent name overrides for Proposal workflow steps.
+type AgentConfig struct {
+	Default      string
+	Analysis     string
+	Execution    string
+	Verification string
+}
+
 // ToolsConfig holds shared and per-step skills configuration.
 type ToolsConfig struct {
 	Shared       []agenticv1alpha1.SkillsSource
@@ -34,6 +42,7 @@ type Config struct {
 	CooldownWindow   time.Duration
 	AllowedReceivers []string
 	Tools            ToolsConfig
+	Agent            AgentConfig
 }
 
 // Default returns a Config with the default values.
@@ -55,6 +64,14 @@ type configFile struct {
 	Analysis         stepEntry        `yaml:"analysis"`
 	Execution        stepEntry        `yaml:"execution"`
 	Verification     stepEntry        `yaml:"verification"`
+	Agent            agentEntry       `yaml:"agent"`
+}
+
+type agentEntry struct {
+	Default      string `yaml:"default"`
+	Analysis     string `yaml:"analysis"`
+	Execution    string `yaml:"execution"`
+	Verification string `yaml:"verification"`
 }
 
 type toolsEntry struct {
@@ -142,6 +159,13 @@ func LoadFromFile(path string, logger *slog.Logger) Config {
 		Analysis:     parseSkills(cf.Analysis.Tools.Skills, "analysis", logger),
 		Execution:    parseSkills(cf.Execution.Tools.Skills, "execution", logger),
 		Verification: parseSkills(cf.Verification.Tools.Skills, "verification", logger),
+	}
+
+	cfg.Agent = AgentConfig{
+		Default:      cf.Agent.Default,
+		Analysis:     cf.Agent.Analysis,
+		Execution:    cf.Agent.Execution,
+		Verification: cf.Agent.Verification,
 	}
 
 	return cfg

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,6 +169,9 @@ func assertDefaults(t *testing.T, cfg Config) {
 	}
 	assertReceiversEqual(t, cfg.AllowedReceivers, defaults.AllowedReceivers)
 	assertEmptyTools(t, cfg.Tools)
+	if cfg.Agent != (AgentConfig{}) {
+		t.Errorf("Agent = %+v, want zero value", cfg.Agent)
+	}
 }
 
 func assertEmptyTools(t *testing.T, tc ToolsConfig) {
@@ -425,6 +428,91 @@ func assertReceiversEqual(t *testing.T, got, want []string) {
 		if got[i] != w {
 			t.Errorf("AllowedReceivers[%d] = %q, want %q", i, got[i], w)
 		}
+	}
+}
+
+func TestParseAgentConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantAgent AgentConfig
+	}{
+		{
+			name: "global default agent only",
+			yaml: `
+agent:
+  default: "my-agent"
+`,
+			wantAgent: AgentConfig{Default: "my-agent"},
+		},
+		{
+			name: "per-step agents only",
+			yaml: `
+agent:
+  analysis: "analyzer"
+  execution: "executor"
+  verification: "verifier"
+`,
+			wantAgent: AgentConfig{
+				Analysis:     "analyzer",
+				Execution:    "executor",
+				Verification: "verifier",
+			},
+		},
+		{
+			name: "global and per-step agents mixed",
+			yaml: `
+agent:
+  default: "global-agent"
+  analysis: "analyzer"
+`,
+			wantAgent: AgentConfig{
+				Default:  "global-agent",
+				Analysis: "analyzer",
+			},
+		},
+		{
+			name:      "no agent section",
+			yaml:      "pollInterval: 30s",
+			wantAgent: AgentConfig{},
+		},
+		{
+			name: "agent section with empty strings",
+			yaml: `
+agent:
+  default: ""
+  analysis: ""
+`,
+			wantAgent: AgentConfig{},
+		},
+		{
+			name: "full agent config",
+			yaml: `
+agent:
+  default: "my-agent"
+  analysis: "analyzer"
+  execution: "executor"
+  verification: "verifier"
+`,
+			wantAgent: AgentConfig{
+				Default:      "my-agent",
+				Analysis:     "analyzer",
+				Execution:    "executor",
+				Verification: "verifier",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfigFile(t, tt.yaml)
+
+			cfg := LoadFromFile(path, quietLogger())
+
+			if cfg.Agent != tt.wantAgent {
+				t.Errorf("Agent = %+v, want %+v", cfg.Agent, tt.wantAgent)
+			}
+		})
 	}
 }
 

--- a/internal/proposal/build.go
+++ b/internal/proposal/build.go
@@ -60,7 +60,7 @@ type requestData struct {
 // The Proposal name is deterministic based on the alert's identity (alertname,
 // namespace, fingerprint), making repeated calls for the same alert safe
 // against duplicate creation via Kubernetes 409 AlreadyExists.
-func Build(a *models.GettableAlert, tools config.ToolsConfig) (*agenticv1alpha1.Proposal, error) {
+func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.AgentConfig) (*agenticv1alpha1.Proposal, error) {
 	if a.Fingerprint == nil {
 		return nil, fmt.Errorf("proposal: alert fingerprint is nil")
 	}
@@ -75,9 +75,9 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig) (*agenticv1alpha1.
 		return nil, err
 	}
 
-	analysis := agenticv1alpha1.ProposalStep{Agent: defaultAgent}
-	execution := agenticv1alpha1.ProposalStep{Agent: defaultAgent}
-	verification := agenticv1alpha1.ProposalStep{Agent: defaultAgent}
+	analysis := agenticv1alpha1.ProposalStep{Agent: resolveAgent(agent.Analysis, agent.Default)}
+	execution := agenticv1alpha1.ProposalStep{Agent: resolveAgent(agent.Execution, agent.Default)}
+	verification := agenticv1alpha1.ProposalStep{Agent: resolveAgent(agent.Verification, agent.Default)}
 
 	if len(tools.Analysis) > 0 {
 		analysis.Tools = agenticv1alpha1.ToolsSpec{Skills: tools.Analysis}
@@ -216,6 +216,16 @@ func sanitizeLabelValue(s string) string {
 	s = strings.TrimRight(s, "-_.")
 
 	return s
+}
+
+func resolveAgent(perStep, global string) string {
+	if perStep != "" {
+		return perStep
+	}
+	if global != "" {
+		return global
+	}
+	return defaultAgent
 }
 
 func truncateDNS(s string, maxLen int) string {

--- a/internal/proposal/build_test.go
+++ b/internal/proposal/build_test.go
@@ -93,7 +93,7 @@ func TestBuild(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := Build(tt.alert, config.ToolsConfig{})
+			p, err := Build(tt.alert, config.ToolsConfig{}, config.AgentConfig{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -132,7 +132,7 @@ func TestBuildNilFingerprint(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
 	a.Fingerprint = nil
 
-	_, err := Build(a, config.ToolsConfig{})
+	_, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 	if err == nil {
 		t.Fatal("expected error for nil fingerprint, got nil")
 	}
@@ -145,7 +145,7 @@ func TestBuildNilFingerprint(t *testing.T) {
 
 func TestBuildWorkflowSteps(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-	p, err := Build(a, config.ToolsConfig{})
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,11 +164,11 @@ func TestBuildWorkflowSteps(t *testing.T) {
 func TestBuildDeterministicNaming(t *testing.T) {
 	a := makeAlert("KubePodCrashLooping", "production", "abcdef1234567890", "critical")
 
-	p1, err := Build(a, config.ToolsConfig{})
+	p1, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 	if err != nil {
 		t.Fatalf("first build: %v", err)
 	}
-	p2, err := Build(a, config.ToolsConfig{})
+	p2, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 	if err != nil {
 		t.Fatalf("second build: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestBuildDeterministicNaming(t *testing.T) {
 func TestBuildAnnotations(t *testing.T) {
 	t.Run("starts-at is RFC3339 UTC", func(t *testing.T) {
 		a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-		p, err := Build(a, config.ToolsConfig{})
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -194,7 +194,7 @@ func TestBuildAnnotations(t *testing.T) {
 
 	t.Run("summary is included", func(t *testing.T) {
 		a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-		p, err := Build(a, config.ToolsConfig{})
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -209,7 +209,7 @@ func TestBuildAnnotations(t *testing.T) {
 		startsAt := strfmt.DateTime(time.Time{})
 		a.StartsAt = &startsAt
 
-		p, err := Build(a, config.ToolsConfig{})
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -225,7 +225,7 @@ func TestBuildAnnotations(t *testing.T) {
 		a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
 		a.Annotations["summary"] = strings.Repeat("x", 300)
 
-		p, err := Build(a, config.ToolsConfig{})
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestBuildRequest(t *testing.T) {
 	a := makeAlert("KubePodCrashLooping", "production", "abcdef12", "critical")
 	a.Annotations["runbook_url"] = "https://runbooks.example.com/KubePodCrashLooping"
 
-	p, err := Build(a, config.ToolsConfig{})
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestBuildRequest(t *testing.T) {
 
 func TestBuildRequestWithoutRunbook(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-	p, err := Build(a, config.ToolsConfig{})
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestSanitizeLabelValue(t *testing.T) {
 
 func TestBuildTypeMeta(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-	p, err := Build(a, config.ToolsConfig{})
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestBuildWithTools(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
 
 	t.Run("empty tools config omits all tools", func(t *testing.T) {
-		p, err := Build(a, config.ToolsConfig{})
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -425,7 +425,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/skills:latest", Paths: []string{"/skills/prometheus"}},
 			},
 		}
-		p, err := Build(a, tc)
+		p, err := Build(a, tc, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -458,7 +458,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/verify:latest", Paths: []string{"/skills/validation"}},
 			},
 		}
-		p, err := Build(a, tc)
+		p, err := Build(a, tc, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -494,7 +494,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/analysis:latest", Paths: []string{"/skills/diagnostic"}},
 			},
 		}
-		p, err := Build(a, tc)
+		p, err := Build(a, tc, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -524,7 +524,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/analysis:latest", Paths: []string{"/skills/diagnostic"}},
 			},
 		}
-		p, err := Build(a, tc)
+		p, err := Build(a, tc, config.AgentConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -532,4 +532,78 @@ func TestBuildWithTools(t *testing.T) {
 			t.Errorf("analysis.agent = %q, want %q", p.Spec.Analysis.Agent, defaultAgent)
 		}
 	})
+}
+
+func TestBuildWithAgentOverrides(t *testing.T) {
+	tests := []struct {
+		name              string
+		agent             config.AgentConfig
+		wantAnalysis      string
+		wantExecution     string
+		wantVerification  string
+	}{
+		{
+			name:             "no agent config uses default for all steps",
+			agent:            config.AgentConfig{},
+			wantAnalysis:     defaultAgent,
+			wantExecution:    defaultAgent,
+			wantVerification: defaultAgent,
+		},
+		{
+			name:             "global agent override applies to all steps",
+			agent:            config.AgentConfig{Default: "my-agent"},
+			wantAnalysis:     "my-agent",
+			wantExecution:    "my-agent",
+			wantVerification: "my-agent",
+		},
+		{
+			name: "per-step overrides take precedence over global",
+			agent: config.AgentConfig{
+				Default:      "global-agent",
+				Analysis:     "analyzer",
+				Execution:    "executor",
+				Verification: "verifier",
+			},
+			wantAnalysis:     "analyzer",
+			wantExecution:    "executor",
+			wantVerification: "verifier",
+		},
+		{
+			name: "mixed config uses per-step where set and global elsewhere",
+			agent: config.AgentConfig{
+				Default:  "global-agent",
+				Analysis: "analyzer",
+			},
+			wantAnalysis:     "analyzer",
+			wantExecution:    "global-agent",
+			wantVerification: "global-agent",
+		},
+		{
+			name:             "per-step only without global falls back to hardcoded default",
+			agent:            config.AgentConfig{Analysis: "analyzer"},
+			wantAnalysis:     "analyzer",
+			wantExecution:    defaultAgent,
+			wantVerification: defaultAgent,
+		},
+	}
+
+	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := Build(a, config.ToolsConfig{}, tt.agent)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.Spec.Analysis.Agent != tt.wantAnalysis {
+				t.Errorf("analysis.agent = %q, want %q", p.Spec.Analysis.Agent, tt.wantAnalysis)
+			}
+			if p.Spec.Execution.Agent != tt.wantExecution {
+				t.Errorf("execution.agent = %q, want %q", p.Spec.Execution.Agent, tt.wantExecution)
+			}
+			if p.Spec.Verification.Agent != tt.wantVerification {
+				t.Errorf("verification.agent = %q, want %q", p.Spec.Verification.Agent, tt.wantVerification)
+			}
+		})
+	}
 }

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -32,6 +32,15 @@ data:
     #         - /skills/prometheus
     #         - /skills/cluster-diagnostics
 
+    # agent: override which agent handles Proposal workflow steps.
+    # 'default' sets the agent for all steps; per-step keys override it.
+    # Falls back to the hardcoded "default" agent when omitted.
+    # agent:
+    #   default: "default"
+    #   analysis: "analysis-agent"
+    #   execution: "execution-agent"
+    #   verification: "verification-agent"
+
     # Per-step tool overrides. When set, these replace the shared tools for that
     # step on the Proposal (maps to spec.{analysis,execution,verification}.tools).
     # analysis:

--- a/openspec/changes/agent-override-config/.openspec.yaml
+++ b/openspec/changes/agent-override-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/agent-override-config/design.md
+++ b/openspec/changes/agent-override-config/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The adapter builds Proposal CRs with all three workflow steps (analysis, execution, verification) hardcoded to the `"default"` agent (`internal/proposal/build.go:78-80`). The operator supports custom agents, but the adapter provides no way to select them. Configuration already supports tools/skills overrides via ConfigMap (`/etc/alerts-adapter/config.yaml`), so adding agent configuration follows the same pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow operators to configure which agent handles Proposal steps via the existing ConfigMap
+- Support a global default agent and optional per-step overrides (analysis, execution, verification)
+- Maintain full backward compatibility — omitting the config results in the current `"default"` behavior
+
+**Non-Goals:**
+- Per-alert agent routing (e.g., mapping specific alert names to specific agents) — future work
+- Validating that the configured agent name exists in the cluster — the operator handles that
+- Environment variable or CLI flag overrides for agent config
+
+## Decisions
+
+### 1. Extend existing ConfigMap YAML with an `agent` section
+
+Add a new top-level `agent` key to `config.yaml` with a `default` field and optional per-step overrides:
+
+```yaml
+agent:
+  default: "my-agent"
+  analysis: "analysis-specialist"
+  execution: "execution-specialist"
+  verification: "verification-specialist"
+```
+
+**Rationale**: Follows the established pattern of the `tools` config. A flat structure (`agent.default`, `agent.analysis`) is simpler than nesting agent names inside the existing `analysis`/`execution`/`verification` step entries, and avoids conflating agent identity with tools configuration.
+
+**Alternative considered**: Putting the agent name inside the existing step entries (e.g., `analysis.agent: "foo"`). Rejected because it mixes two concerns — tool configuration and agent routing — and would complicate the YAML structure for the common case of setting a single global agent.
+
+### 2. New `AgentConfig` struct in `internal/config`
+
+```go
+type AgentConfig struct {
+    Default      string
+    Analysis     string
+    Execution    string
+    Verification string
+}
+```
+
+`Build()` receives `AgentConfig` alongside `ToolsConfig`. For each step, it uses the per-step agent if set, then falls back to `AgentConfig.Default`, then falls back to the hardcoded `"default"` constant.
+
+**Rationale**: The three-level fallback (per-step → global → hardcoded default) gives operators granular control while keeping zero-config deployment unchanged. Passing `AgentConfig` as a separate parameter (not embedded in `ToolsConfig`) keeps the two concerns decoupled.
+
+### 3. Validation: empty strings are ignored, no existence checks
+
+Empty agent name strings are treated as "not configured" and fall through to the next fallback level. No validation is performed against the cluster — the operator validates agent references when it processes the Proposal.
+
+**Rationale**: Consistent with how the adapter handles tools config (no validation of image references). Keeps the adapter simple and stateless.
+
+## Risks / Trade-offs
+
+- **Typo in agent name silently accepted** → The operator will fail the Proposal with a clear error in its status conditions. The adapter logs which agent was assigned to each Proposal at creation time, making misconfiguration diagnosable.
+- **No per-alert routing** → Operators who need different agents for different alert types must deploy multiple adapter instances with different configs. This is acceptable for the initial implementation and can be extended later without breaking changes.

--- a/openspec/changes/agent-override-config/proposal.md
+++ b/openspec/changes/agent-override-config/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The adapter hardcodes `"default"` as the agent for all three Proposal workflow steps (analysis, execution, verification). Operators deploying custom agents cannot direct alerts to them — every Proposal always uses the default agent regardless of the alert type or operational context.
+
+## What Changes
+
+- Add an optional `agent` configuration section to the ConfigMap that lets operators set a global agent name and per-step overrides (analysis, execution, verification)
+- Update `Build()` to accept an agent configuration and use it instead of the hardcoded `"default"` when set
+- Fall back to `"default"` when no agent override is configured (backward compatible, no **BREAKING** changes)
+
+## Capabilities
+
+### New Capabilities
+- `agent-config`: ConfigMap-based agent name configuration with global and per-step granularity
+
+### Modified Capabilities
+- `proposal-building`: Proposal steps use configurable agent names instead of hardcoded `"default"`
+- `configmap-config`: ConfigMap parsing includes the new `agent` section
+
+## Impact
+
+- **Code**: `internal/config/config.go` (new struct + parsing), `internal/proposal/build.go` (accept agent config), `internal/adapter/adapter.go` (pass config through)
+- **Manifests**: `manifests/configmap.yaml` (document new optional section)
+- **APIs**: No CRD changes — uses existing `ProposalStep.Agent` field
+- **Dependencies**: None — no new imports

--- a/openspec/changes/agent-override-config/specs/agent-config/spec.md
+++ b/openspec/changes/agent-override-config/specs/agent-config/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Parse agent configuration from ConfigMap
+The system SHALL parse an optional `agent` section from the `config.yaml` data in the `alerts-adapter-config` ConfigMap. The section supports a `default` field for the global agent name and optional per-step overrides (`analysis`, `execution`, `verification`).
+
+#### Scenario: ConfigMap contains a global default agent
+- **WHEN** the ConfigMap `config.yaml` contains `agent.default` set to `"my-agent"`
+- **THEN** the loaded `Config` SHALL have `AgentConfig.Default` set to `"my-agent"`
+
+#### Scenario: ConfigMap contains per-step agent overrides
+- **WHEN** the ConfigMap `config.yaml` contains `agent.analysis` set to `"analyzer"`, `agent.execution` set to `"executor"`, and `agent.verification` set to `"verifier"`
+- **THEN** the loaded `Config` SHALL have the corresponding `AgentConfig` fields set to those values
+
+#### Scenario: ConfigMap contains only a global agent with no per-step overrides
+- **WHEN** the ConfigMap `config.yaml` contains `agent.default` set to `"my-agent"` but no `agent.analysis`, `agent.execution`, or `agent.verification`
+- **THEN** the loaded `Config` SHALL have `AgentConfig.Default` set to `"my-agent"` and all per-step fields empty
+
+#### Scenario: ConfigMap has no agent section
+- **WHEN** the ConfigMap `config.yaml` does not contain an `agent` key
+- **THEN** the loaded `Config` SHALL have an empty `AgentConfig` (all fields empty strings) and no error is logged
+
+#### Scenario: ConfigMap does not exist
+- **WHEN** the ConfigMap is not found in the cluster
+- **THEN** the loaded `Config` SHALL use defaults for all parameters and have an empty `AgentConfig`
+
+### Requirement: Resolve the effective agent for each Proposal step
+The system SHALL resolve the agent name for each workflow step using a three-level fallback: per-step override → global default → hardcoded `"default"`.
+
+#### Scenario: Per-step agent set for analysis
+- **WHEN** `AgentConfig.Analysis` is `"analyzer"` and `AgentConfig.Default` is `"my-agent"`
+- **THEN** the analysis step SHALL use `"analyzer"`
+
+#### Scenario: Per-step agent not set, global default set
+- **WHEN** `AgentConfig.Analysis` is empty and `AgentConfig.Default` is `"my-agent"`
+- **THEN** the analysis step SHALL use `"my-agent"`
+
+#### Scenario: No agent config set at all
+- **WHEN** both `AgentConfig.Analysis` and `AgentConfig.Default` are empty
+- **THEN** the analysis step SHALL use `"default"`
+
+#### Scenario: Mixed per-step and global configuration
+- **WHEN** `AgentConfig.Default` is `"global-agent"`, `AgentConfig.Analysis` is `"analyzer"`, `AgentConfig.Execution` is empty, and `AgentConfig.Verification` is `"verifier"`
+- **THEN** analysis SHALL use `"analyzer"`, execution SHALL use `"global-agent"`, and verification SHALL use `"verifier"`

--- a/openspec/changes/agent-override-config/specs/configmap-config/spec.md
+++ b/openspec/changes/agent-override-config/specs/configmap-config/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Load configuration from a ConfigMap each reconcile cycle
+The system SHALL read the `alerts-adapter-config` ConfigMap from the adapter's namespace on each reconcile cycle and apply the configuration values for that cycle, including the optional agent configuration.
+
+#### Scenario: ConfigMap exists with valid YAML
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains valid YAML with valid duration values
+- **THEN** the system uses the values from the ConfigMap for that reconcile cycle
+
+#### Scenario: ConfigMap exists with partial YAML
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains valid YAML with only some fields specified
+- **THEN** the system uses the specified values and falls back to defaults for missing fields
+
+#### Scenario: ConfigMap exists with agent section
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains an `agent` section with `default` and/or per-step overrides
+- **THEN** the system populates `Config.Agent` with the specified values for that reconcile cycle
+
+#### Scenario: ConfigMap exists without agent section
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key does not contain an `agent` section
+- **THEN** the system uses an empty `AgentConfig` (all fields empty, resulting in hardcoded `"default"` agent for all steps)
+
+#### Scenario: ConfigMap exists with invalid duration value
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains an unparseable duration string for one or more fields
+- **THEN** the system falls back to the default value for each invalid field and logs a warning for each invalid field
+
+#### Scenario: ConfigMap exists with non-positive duration value
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains a zero or negative duration (e.g., `pollInterval: 0s` or `initialDelay: -1m`)
+- **THEN** the system falls back to the default value for each non-positive field and logs a warning for each non-positive field
+
+#### Scenario: ConfigMap exists with invalid YAML
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains content that is not valid YAML
+- **THEN** the system falls back to all default values and logs a warning
+
+#### Scenario: ConfigMap exists without the config.yaml key
+- **WHEN** the `alerts-adapter-config` ConfigMap exists but does not contain a `config.yaml` key
+- **THEN** the system falls back to all default values

--- a/openspec/changes/agent-override-config/specs/proposal-building/spec.md
+++ b/openspec/changes/agent-override-config/specs/proposal-building/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Configure all three workflow steps with tools
+The system SHALL set the analysis, execution, and verification steps on the Proposal, each referencing a configurable agent name resolved from the agent configuration. The system SHALL support shared tools and per-step tool overrides.
+
+#### Scenario: Built Proposal has full workflow with default agent
+- **WHEN** a Proposal is built from any alert and no agent configuration is provided
+- **THEN** `spec.analysis`, `spec.execution`, and `spec.verification` all have `agent` set to `"default"`
+
+#### Scenario: Built Proposal with global agent override
+- **WHEN** a Proposal is built and the agent configuration has `Default` set to `"my-agent"` with no per-step overrides
+- **THEN** `spec.analysis`, `spec.execution`, and `spec.verification` all have `agent` set to `"my-agent"`
+
+#### Scenario: Built Proposal with per-step agent overrides
+- **WHEN** a Proposal is built and the agent configuration has per-step overrides for analysis, execution, and verification
+- **THEN** each step's `agent` field SHALL be set to the corresponding per-step override value
+
+#### Scenario: Built Proposal with mixed agent configuration
+- **WHEN** a Proposal is built with `AgentConfig.Default` set to `"global-agent"`, `AgentConfig.Analysis` set to `"analyzer"`, and `AgentConfig.Execution` empty
+- **THEN** `spec.analysis.agent` SHALL be `"analyzer"`, `spec.execution.agent` SHALL be `"global-agent"`, and `spec.verification.agent` SHALL use the fallback chain
+
+#### Scenario: Built Proposal with shared skills configured
+- **WHEN** a Proposal is built and shared skills configuration is provided with one or more skills entries
+- **THEN** `spec.tools.skills` SHALL contain the configured skills entries with their images and paths
+
+#### Scenario: Built Proposal with per-step skills configured
+- **WHEN** a Proposal is built and per-step skills are configured for analysis, execution, or verification
+- **THEN** the corresponding `spec.{step}.tools.skills` SHALL contain the configured skills entries for that step
+
+#### Scenario: Built Proposal with both shared and per-step skills
+- **WHEN** a Proposal is built with both shared skills and per-step skills for a given step
+- **THEN** `spec.tools.skills` SHALL contain the shared skills AND `spec.{step}.tools.skills` SHALL contain the per-step skills for steps that have overrides
+
+#### Scenario: Built Proposal with no tools configured
+- **WHEN** a Proposal is built and no tools configuration is provided (all slices empty)
+- **THEN** `spec.tools` SHALL be omitted from the Proposal (zero value) and no per-step tools SHALL be set

--- a/openspec/changes/agent-override-config/tasks.md
+++ b/openspec/changes/agent-override-config/tasks.md
@@ -1,0 +1,23 @@
+## 1. Configuration Parsing
+
+- [x] 1.1 Add `AgentConfig` struct to `internal/config/config.go` with `Default`, `Analysis`, `Execution`, `Verification` string fields
+- [x] 1.2 Add `Agent AgentConfig` field to the `Config` struct
+- [x] 1.3 Add `agentEntry` to `configFile` struct with YAML tag `agent` and fields `Default`, `Analysis`, `Execution`, `Verification`
+- [x] 1.4 Parse the agent section in `LoadFromFile` and populate `cfg.Agent` from the deserialized `configFile`
+- [x] 1.5 Add tests for agent config parsing: global only, per-step only, mixed, missing section, empty strings
+
+## 2. Proposal Building
+
+- [x] 2.1 Add `config.AgentConfig` parameter to `Build()` function signature
+- [x] 2.2 Add `resolveAgent` helper that implements the three-level fallback: per-step → global default → hardcoded `"default"`
+- [x] 2.3 Replace hardcoded `defaultAgent` assignment with `resolveAgent` calls for each step
+- [x] 2.4 Update all existing callers of `Build()` in `internal/adapter/adapter.go` to pass `cfg.Agent`
+- [x] 2.5 Add tests for `Build()` with agent overrides: no config (backward compat), global override, per-step overrides, mixed config
+
+## 3. Test Fixture Updates
+
+- [x] 3.1 Update existing `Build()` tests to pass the new `AgentConfig` parameter (zero value for backward compat)
+
+## 4. Manifest and Documentation
+
+- [x] 4.1 Update `manifests/configmap.yaml` with a commented-out `agent` section showing the available fields


### PR DESCRIPTION
Add AgentConfig to the ConfigMap-based configuration, allowing operators to override which agent handles Proposal workflow steps (analysis, execution, verification). Supports a global default agent and optional per-step overrides with three-level fallback: per-step → global → hardcoded "default".

- Add AgentConfig struct and parsing in internal/config
- Add resolveAgent helper in internal/proposal/build.go
- Update Build() signature to accept AgentConfig
- Add table-driven tests for config parsing and agent resolution
- Document agent section in manifests/configmap.yaml


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional agent configuration in the app settings, including a global default and per-step overrides for analysis, execution, and verification.
  * Proposal generation now uses the configured agent names when provided, with safe fallbacks to existing defaults.

* **Bug Fixes**
  * Improved configuration handling so missing or partial agent settings continue to work without breaking proposal creation.

* **Documentation**
  * Updated configuration examples and release spec notes to describe the new agent override options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->