### PR TITLE
fix: use UBI base images and add required labels for Konflux EC

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,16 +1,28 @@
-FROM golang:1.26 AS builder
-
-WORKDIR /app
+FROM registry.redhat.io/ubi9/go-toolset:9.8-1782852234 AS builder
 
 COPY go.mod go.sum* ./
 RUN go mod download
 
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /bin/alerts-adapter ./cmd/alerts-adapter
+COPY cmd/ cmd/
+COPY internal/ internal/
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o ./alerts-adapter ./cmd/alerts-adapter
 
-FROM golang:1.26
+FROM registry.access.redhat.com/ubi9-micro:latest
 
-COPY --from=builder /bin/alerts-adapter /usr/local/bin/alerts-adapter
+LABEL com.redhat.component="lightspeed-agentic-alerts-adapter" \
+      name="openshift-lightspeed-1/lightspeed-agentic-alerts-adapter" \
+      version="0.1.0" \
+      release="1" \
+      summary="Lightspeed Agentic Alerts Adapter" \
+      description="Polls OpenShift AlertManager for firing alerts and creates Proposal CRs to trigger automated remediation via the Lightspeed Agentic operator." \
+      io.k8s.description="Polls OpenShift AlertManager for firing alerts and creates Proposal CRs to trigger automated remediation via the Lightspeed Agentic operator." \
+      url="https://github.com/openshift/lightspeed-agentic-alerts-adapter" \
+      vendor="Red Hat, Inc." \
+      distribution-scope="public" \
+      cpe="cpe:/a:redhat:openshift_lightspeed:1::el9"
+
+COPY LICENSE /licenses/LICENSE
+COPY --from=builder /opt/app-root/src/alerts-adapter /usr/local/bin/alerts-adapter
 
 USER 1001
 


### PR DESCRIPTION
Switch builder image from docker.io/library/golang to registry.redhat.io/ubi9/go-toolset and runtime image to registry.access.redhat.com/ubi9-micro to satisfy the base_image_registries.base_image_permitted policy.

Add all required Red Hat container labels to resolve labels.required_labels violations in the Enterprise Contract verification pipeline.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build and runtime base images to Red Hat UBI variants.
  * Added container metadata labels for better platform compatibility and image identification.
  * Kept the same startup behavior: the app still runs as a non-root user and starts with the same entrypoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->