### PR TITLE
fix: enable hermetic and source-build in Tekton pipelines

### DIFF
--- a/.tekton/lightspeed-agentic-alerts-adapter-pull-request.yaml
+++ b/.tekton/lightspeed-agentic-alerts-adapter-pull-request.yaml
@@ -31,6 +31,12 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/lightspeed-agentic-alerts-adapter-push.yaml
+++ b/.tekton/lightspeed-agentic-alerts-adapter-push.yaml
@@ -28,6 +28,12 @@ spec:
     - linux/x86_64
   - name: dockerfile
     value: Containerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Set hermetic=true and build-source-image=true in both push and pull-request PipelineRun definitions to resolve EC violations: hermetic_task.hermetic,
tasks.required_tasks_found, and source_image.exists.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline settings to run in hermetic mode.
  * Enabled source image creation during builds, improving consistency and traceability of generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->