### PR TITLE
refactor: use startsAt hash in Proposal naming instead of fingerprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ go test -run TestFunctionName/subtest_name ./internal/adapter/
 Three internal packages, each behind an interface, wired together in `cmd/alerts-adapter/main.go`:
 
 - **`internal/alertmanager`** — AlertManager API client. Reads bearer token on every call (handles rotation). TLS via in-cluster CA. Implements `adapter.AlertSource`.
-- **`internal/proposal`** — Two concerns: `build.go` translates an alert into a `Proposal` CR (deterministic name from fingerprint, embedded Go template `request.tmpl` for the request field); `client.go` wraps controller-runtime to create/list Proposals. Implements `adapter.ProposalClient`.
+- **`internal/proposal`** — Two concerns: `build.go` translates an alert into a `Proposal` CR (deterministic name from alertname, namespace, and startsAt hash; embedded Go template `request.tmpl` for the request field); `client.go` wraps controller-runtime to create/list Proposals. Implements `adapter.ProposalClient`.
 - **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `initialDelay` (5m), with an active (non-terminal) Proposal, or within `cooldownWindow` (1h) of a terminal Proposal. Matching is by `alert-fingerprint` label (first 8 chars).
 
 The Proposal CRD types come from `github.com/openshift/lightspeed-agentic-operator/api`.
@@ -36,7 +36,7 @@ The Proposal CRD types come from `github.com/openshift/lightspeed-agentic-operat
 - Polls (not webhooks) for resilience — restart immediately sees all firing alerts.
 - Proposals always created in `openshift-lightspeed` namespace.
 - 409 AlreadyExists on create is expected and handled as a no-op (returns `false, nil`).
-- Fingerprint prefix (8 chars) is used for both Proposal naming and dedup matching (`proposal.FingerprintLen`).
+- Fingerprint prefix (8 chars) is used for dedup matching via the `alert-fingerprint` label (`proposal.FingerprintLen`). Proposal names use a hash of the alert's `startsAt` timestamp instead, so different occurrences of the same alert produce distinct Proposals.
 - Terminal phases: Completed, Failed, Denied, Escalated.
 
 ## Conventions

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,7 @@ This means restarts, upgrades, and pod rescheduling are inherently safe. The ada
 
 ### Alert-to-Proposal Cardinality
 
-The adapter maintains a **1:1 relationship** between alerts and Proposals. Each unique firing alert (identified by its AlertManager fingerprint) maps to exactly one Proposal. There is no alert grouping — if 10 alerts are firing, 10 Proposals are created (subject to deduplication checks).
+The adapter maintains a **1:1 relationship** between alert occurrences and Proposals. Each firing alert occurrence (identified by its AlertManager fingerprint and `startsAt` timestamp) maps to exactly one Proposal. There is no alert grouping — if 10 alerts are firing, 10 Proposals are created (subject to deduplication checks). If the same alert resolves and fires again (new `startsAt`), it produces a new Proposal with a distinct name.
 
 ### Poll Loop
 
@@ -111,27 +111,29 @@ Two configurable parameters control deduplication. Both are configurable via the
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `InitialDelay` | Minimum time an alert must be firing before the adapter creates a Proposal. Filters transient alerts that resolve on their own. Uses the alert's `startsAt` field from AlertManager — no in-memory tracking needed. | 5 minutes |
-| `CooldownWindow` | After a Proposal reaches a terminal phase (Completed, Failed, Escalated, Denied), minimum time before the adapter creates a new Proposal for the same alert fingerprint. Prevents flooding for flapping alerts. Uses the terminal Proposal's condition timestamps. | 1 hour |
+| `CooldownWindow` | After a Proposal reaches a terminal phase (Completed, Failed, Escalated, Denied), minimum time before the adapter creates a new Proposal for the same alert (matched by fingerprint label). Prevents flooding for flapping alerts. Uses the terminal Proposal's condition timestamps. | 1 hour |
 
 ### Race Condition Prevention
 
-The adapter uses **deterministic Proposal naming** derived from alert metadata. The fingerprint is not computed by the adapter — AlertManager computes it as a hash of the alert's label set and returns it in the `GET /api/v2/alerts` response.
+The adapter uses **deterministic Proposal naming** derived from alert metadata. The name includes an 8-character SHA-256 hash of the alert's `startsAt` timestamp (RFC 3339 UTC), ensuring each alert occurrence gets a unique Proposal name.
 
 ```
-{alertname}-{namespace}-{fingerprint[:8]}
+{alertname}-{namespace}-{startsAtHash}
 ```
 
 Examples:
-- `kubepodcrashlooping-production-a1b2c3d4`
-- `etcdhighfsyncdurations--f9e8d7c6` (no namespace for cluster-scoped alerts)
+- `kubepodcrashlooping-production-895c8977`
+- `etcdhighfsyncdurations-a3f1b2c4` (no namespace for cluster-scoped alerts)
 
-Components are sanitized to conform to DNS subdomain rules (RFC 1123): lowercased, non-alphanumeric characters replaced, truncated to fit the 253-character limit.
+Components are sanitized to conform to DNS subdomain rules (RFC 1123): lowercased, non-alphanumeric characters replaced, truncated to fit the 63-character limit.
+
+Deduplication uses the `alert-fingerprint` label (first 8 chars of AlertManager's fingerprint, a hash of the alert's label set) to match alerts to existing Proposals. The fingerprint is not part of the Proposal name — it is only stored as a label for matching.
 
 ### Alert to Proposal Mapping
 
 #### Proposal Name
 
-Deterministic: `{alertname}-{namespace}-{fingerprint[:8]}` (see above).
+Deterministic: `{alertname}-{namespace}-{startsAtHash}` (see above).
 
 #### Namespace
 
@@ -384,6 +386,6 @@ Tools/skills configuration is also supported — see [README.md](README.md#confi
 - **Prometheus metrics**: `alerts_adapter_polls_total`, `proposals_created_total`, `errors_total`, `poll_duration_seconds`.
 - **Adapter-specific analysis output schema**: Inject custom fields into `analysisOutput.schema` for alert correlation, affected services topology.
 - **Workflow selection**: Choose different workflow patterns (advisory, assisted, full remediation) based on alert labels.
-- **Multi-replica support**: Leader election or sharded alert processing for high availability. With deterministic Proposal naming, concurrent replicas attempting to create the same Proposal would result in one succeeding and the other receiving `409 Conflict (AlreadyExists)` — the adapter already treats 409 as success, so basic multi-replica operation works without coordination, though leader election would reduce redundant API calls.
+- **Multi-replica support**: Leader election or sharded alert processing for high availability. With deterministic Proposal naming (based on alert identity and startsAt), concurrent replicas attempting to create the same Proposal would result in one succeeding and the other receiving `409 Conflict (AlreadyExists)` — the adapter already treats 409 as success, so basic multi-replica operation works without coordination, though leader election would reduce redundant API calls.
 - **Token budgets**: Protect against alert storms hitting model rate limits. At minimum add jitter to Proposal creation; consider an adapter-level or OLS-level token budget to prevent runaway costs.
 - **Retry clarity for unparseable alerts**: When an alert cannot be parsed, the adapter skips it but will keep retrying on each subsequent poll until the alert disappears. Consider explicit retry-on-next-interval semantics with backoff or a skip list.

--- a/internal/proposal/build.go
+++ b/internal/proposal/build.go
@@ -3,7 +3,9 @@ package proposal
 
 import (
 	"bytes"
+	"crypto/sha256"
 	_ "embed"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strings"
@@ -58,8 +60,10 @@ type requestData struct {
 
 // Build constructs a Proposal from a single Alertmanager GettableAlert.
 // The Proposal name is deterministic based on the alert's identity (alertname,
-// namespace, fingerprint), making repeated calls for the same alert safe
-// against duplicate creation via Kubernetes 409 AlreadyExists.
+// namespace, startsAt), making repeated calls for the same alert occurrence
+// safe against duplicate creation via Kubernetes 409 AlreadyExists.
+// Different occurrences of the same alert (different startsAt) produce
+// distinct Proposal names, allowing re-creation after cooldown.
 func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.AgentConfig) (*agenticv1alpha1.Proposal, error) {
 	if a.Fingerprint == nil {
 		return nil, fmt.Errorf("proposal: alert fingerprint is nil")
@@ -69,6 +73,11 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 	namespace := a.Labels["namespace"]
 	fingerprint := *a.Fingerprint
 	severity := a.Labels["severity"]
+
+	if a.StartsAt == nil {
+		return nil, fmt.Errorf("proposal: alert startsAt is nil")
+	}
+	startsAt := time.Time(*a.StartsAt)
 
 	request, err := buildRequest(a)
 	if err != nil {
@@ -95,7 +104,7 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 			Kind:       "Proposal",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        buildName(alertName, namespace, fingerprint),
+			Name:        buildName(alertName, namespace, startsAt),
 			Namespace:   proposalNamespace,
 			Labels:      buildLabels(alertName, severity, fingerprint),
 			Annotations: buildAnnotations(a),
@@ -119,15 +128,14 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 	return p, nil
 }
 
-// buildName produces a deterministic DNS-compatible name: {alertname}-{namespace}-{fingerprint[:8]}
-// or {alertname}-{fingerprint[:8]} for cluster-scoped alerts.
+// buildName produces a deterministic DNS-compatible name: {alertname}-{namespace}-{startsAtHash}
+// or {alertname}-{startsAtHash} for cluster-scoped alerts.
+// The startsAt hash is an 8-character hex digest of the alert's start time,
+// ensuring each alert occurrence gets a unique Proposal name.
 // The name is capped at 63 characters because the agentic operator uses it as a
 // Kubernetes label value, which has a 63-byte limit.
-func buildName(alertName, namespace, fingerprint string) string {
-	fp := fingerprint
-	if len(fp) > FingerprintLen {
-		fp = fp[:FingerprintLen]
-	}
+func buildName(alertName, namespace string, startsAt time.Time) string {
+	hash := startsAtHash(startsAt)
 
 	name := strings.ToLower(alertName)
 	name = invalidDNSChars.ReplaceAllString(name, "-")
@@ -135,20 +143,27 @@ func buildName(alertName, namespace, fingerprint string) string {
 	if namespace != "" {
 		ns := strings.ToLower(namespace)
 		ns = invalidDNSChars.ReplaceAllString(ns, "-")
-		combined := name + "-" + ns + "-" + fp
+		combined := name + "-" + ns + "-" + hash
 		if len(combined) <= maxLabelValueLen {
 			return combined
 		}
-		available := max(maxLabelValueLen-len(ns)-len(fp)-2, 1)
-		return truncateDNS(name, available) + "-" + ns + "-" + fp
+		available := max(maxLabelValueLen-len(ns)-len(hash)-2, 1)
+		return truncateDNS(name, available) + "-" + ns + "-" + hash
 	}
 
-	combined := name + "-" + fp
+	combined := name + "-" + hash
 	if len(combined) <= maxLabelValueLen {
 		return combined
 	}
-	available := maxLabelValueLen - len(fp) - 1
-	return truncateDNS(name, available) + "-" + fp
+	available := maxLabelValueLen - len(hash) - 1
+	return truncateDNS(name, available) + "-" + hash
+}
+
+const startsAtHashLen = 8
+
+func startsAtHash(t time.Time) string {
+	h := sha256.Sum256([]byte(t.UTC().Format(time.RFC3339)))
+	return hex.EncodeToString(h[:])[:startsAtHashLen]
 }
 
 // buildLabels sets Kubernetes labels for alert traceability and filtering.

--- a/internal/proposal/build_test.go
+++ b/internal/proposal/build_test.go
@@ -49,7 +49,7 @@ func TestBuild(t *testing.T) {
 		{
 			name:              "namespaced alert",
 			alert:             makeAlert("KubePodCrashLooping", "production", "abcdef1234567890", "critical"),
-			expectedName:      "kubepodcrashlooping-production-abcdef12",
+			expectedName:      "kubepodcrashlooping-production-895c8977",
 			expectedNamespace: proposalNamespace,
 			expectedTargetNS:  []string{"production"},
 			expectedLabels: map[string]string{
@@ -66,7 +66,7 @@ func TestBuild(t *testing.T) {
 				delete(a.Labels, "namespace")
 				return a
 			}(),
-			expectedName:      "clusterversionavailable-ff00ff00",
+			expectedName:      "clusterversionavailable-895c8977",
 			expectedNamespace: proposalNamespace,
 			expectedTargetNS:  nil,
 			expectedLabels: map[string]string{
@@ -79,7 +79,7 @@ func TestBuild(t *testing.T) {
 		{
 			name:              "short fingerprint (less than 8 chars)",
 			alert:             makeAlert("TestAlert", "ns", "abc", "warning"),
-			expectedName:      "testalert-ns-abc",
+			expectedName:      "testalert-ns-895c8977",
 			expectedNamespace: proposalNamespace,
 			expectedTargetNS:  []string{"ns"},
 			expectedLabels: map[string]string{
@@ -138,6 +138,21 @@ func TestBuildNilFingerprint(t *testing.T) {
 	}
 
 	want := "fingerprint is nil"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want it to contain %q", err, want)
+	}
+}
+
+func TestBuildNilStartsAt(t *testing.T) {
+	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
+	a.StartsAt = nil
+
+	_, err := Build(a, config.ToolsConfig{}, config.AgentConfig{})
+	if err == nil {
+		t.Fatal("expected error for nil startsAt, got nil")
+	}
+
+	want := "startsAt is nil"
 	if !strings.Contains(err.Error(), want) {
 		t.Errorf("error = %q, want it to contain %q", err, want)
 	}
@@ -270,60 +285,70 @@ func TestBuildRequestWithoutRunbook(t *testing.T) {
 }
 
 func TestBuildName(t *testing.T) {
+	testTime := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	hash := startsAtHash(testTime)
+
 	tests := []struct {
-		name        string
-		alertName   string
-		namespace   string
-		fingerprint string
-		expected    string
+		name      string
+		alertName string
+		namespace string
+		startsAt  time.Time
+		expected  string
 	}{
 		{
-			name:        "standard namespaced",
-			alertName:   "KubePodCrashLooping",
-			namespace:   "production",
-			fingerprint: "abcdef1234567890",
-			expected:    "kubepodcrashlooping-production-abcdef12",
+			name:      "standard namespaced",
+			alertName: "KubePodCrashLooping",
+			namespace: "production",
+			startsAt:  testTime,
+			expected:  "kubepodcrashlooping-production-" + hash,
 		},
 		{
-			name:        "cluster-scoped",
-			alertName:   "ClusterReady",
-			namespace:   "",
-			fingerprint: "ff00ff00ff00ff00",
-			expected:    "clusterready-ff00ff00",
+			name:      "cluster-scoped",
+			alertName: "ClusterReady",
+			namespace: "",
+			startsAt:  testTime,
+			expected:  "clusterready-" + hash,
 		},
 		{
-			name:        "invalid characters replaced",
-			alertName:   "Alert_With:Special/Chars",
-			namespace:   "my ns!",
-			fingerprint: "aabbccdd",
-			expected:    "alert-with-special-chars-my-ns--aabbccdd",
+			name:      "invalid characters replaced",
+			alertName: "Alert_With:Special/Chars",
+			namespace: "my ns!",
+			startsAt:  testTime,
+			expected:  "alert-with-special-chars-my-ns--" + hash,
 		},
 		{
-			name:        "long name truncated to 63 chars with namespace",
-			alertName:   "AlertmanagerReceiversNotConfigured",
-			namespace:   "openshift-monitoring",
-			fingerprint: "72bc0ebbaa112233",
-			expected:    "alertmanagerreceiversnotconfigure-openshift-monitoring-72bc0ebb",
+			name:      "long name truncated to 63 chars with namespace",
+			alertName: "AlertmanagerReceiversNotConfigured",
+			namespace: "openshift-monitoring",
+			startsAt:  testTime,
+			expected:  "alertmanagerreceiversnotconfigure-openshift-monitoring-" + hash,
 		},
 		{
-			name:        "long alert name truncated with namespace",
-			alertName:   strings.Repeat("a", 250),
-			namespace:   "ns",
-			fingerprint: "12345678",
-			expected:    strings.Repeat("a", maxLabelValueLen-len("-ns-12345678")) + "-ns-12345678",
+			name:      "long alert name truncated with namespace",
+			alertName: strings.Repeat("a", 250),
+			namespace: "ns",
+			startsAt:  testTime,
+			expected:  strings.Repeat("a", maxLabelValueLen-len("-ns-"+hash)) + "-ns-" + hash,
 		},
 		{
-			name:        "long alert name truncated without namespace",
-			alertName:   strings.Repeat("a", 250),
-			namespace:   "",
-			fingerprint: "12345678",
-			expected:    strings.Repeat("a", maxLabelValueLen-len("-12345678")) + "-12345678",
+			name:      "long alert name truncated without namespace",
+			alertName: strings.Repeat("a", 250),
+			namespace: "",
+			startsAt:  testTime,
+			expected:  strings.Repeat("a", maxLabelValueLen-len("-"+hash)) + "-" + hash,
+		},
+		{
+			name:      "different startsAt produces different name",
+			alertName: "KubePodCrashLooping",
+			namespace: "production",
+			startsAt:  testTime.Add(time.Hour),
+			expected:  "kubepodcrashlooping-production-" + startsAtHash(testTime.Add(time.Hour)),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildName(tt.alertName, tt.namespace, tt.fingerprint)
+			got := buildName(tt.alertName, tt.namespace, tt.startsAt)
 			if got != tt.expected {
 				t.Errorf("buildName() = %q, want %q", got, tt.expected)
 			}

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -16,7 +16,7 @@ data:
 
     # cooldownWindow: after a Proposal reaches a terminal state (Completed, Failed,
     # Denied, Escalated), how long to wait before creating a new Proposal for the
-    # same alert fingerprint. Prevents flooding for flapping alerts.
+    # same alert (matched by fingerprint label). Prevents flooding for flapping alerts.
     # Default: 1h
     cooldownWindow: 1h
     allowedReceivers:

--- a/openspec/specs/proposal-building/spec.md
+++ b/openspec/specs/proposal-building/spec.md
@@ -7,11 +7,11 @@ The system SHALL convert an Alertmanager `GettableAlert` into a `Proposal` custo
 
 #### Scenario: Alert with namespace label
 - **WHEN** the alert has a `namespace` label
-- **THEN** the Proposal name is `{alertname}-{namespace}-{fingerprint[:8]}`, `spec.targetNamespaces` is set to `[namespace]`, and the Proposal is created in `openshift-lightspeed`
+- **THEN** the Proposal name is `{alertname}-{namespace}-{startsAtHash}`, `spec.targetNamespaces` is set to `[namespace]`, and the Proposal is created in `openshift-lightspeed`
 
 #### Scenario: Cluster-scoped alert (no namespace)
 - **WHEN** the alert has no `namespace` label
-- **THEN** the Proposal name is `{alertname}-{fingerprint[:8]}`, `spec.targetNamespaces` is omitted, and the Proposal is created in `openshift-lightspeed`
+- **THEN** the Proposal name is `{alertname}-{startsAtHash}`, `spec.targetNamespaces` is omitted, and the Proposal is created in `openshift-lightspeed`
 
 #### Scenario: Deterministic naming produces idempotent creates
 - **WHEN** the same alert is passed to Build twice
@@ -26,7 +26,7 @@ The system SHALL sanitize alert values to conform to Kubernetes naming and label
 
 #### Scenario: Proposal name exceeds 63 characters
 - **WHEN** the computed name would exceed 63 characters (the Kubernetes label value limit, since the agentic operator uses the Proposal name as a label value)
-- **THEN** the alertname component is truncated to fit within the 63-character limit while preserving the namespace and fingerprint suffix
+- **THEN** the alertname component is truncated to fit within the 63-character limit while preserving the namespace and startsAt hash suffix
 
 #### Scenario: Label value exceeds 63 characters
 - **WHEN** an alert field used as a label value exceeds 63 characters


### PR DESCRIPTION
Replace the alert fingerprint suffix in Proposal resource names with an 8-character SHA-256 hash of the alert's startsAt timestamp. This ensures each alert occurrence produces a unique Proposal name, allowing the cooldown window to work correctly without requiring deletion of terminal Proposals. The fingerprint remains in labels for dedup matching.


Assisted-by: Claude Code:claude-opus-4-6