### PR TITLE
fix: print the config values in more human readable format

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -52,9 +52,9 @@ func New(alerts AlertSource, proposals ProposalClient, cfg config.Config, logger
 // Run starts the poll loop, blocking until the context is cancelled.
 func (a *Adapter) Run(ctx context.Context) error {
 	a.logger.Info("adapter started",
-		"pollInterval", a.cfg.PollInterval,
-		"initialDelay", a.cfg.InitialDelay,
-		"cooldownWindow", a.cfg.CooldownWindow,
+		"pollInterval", a.cfg.PollInterval.String(),
+		"initialDelay", a.cfg.InitialDelay.String(),
+		"cooldownWindow", a.cfg.CooldownWindow.String(),
 		"allowedReceivers", a.cfg.AllowedReceivers,
 	)
 


### PR DESCRIPTION
To print the log statement as
<img width="1440" height="39" alt="image" src="https://github.com/user-attachments/assets/a9276db0-5dd0-4ca3-85c0-d0f6fe5c0a4b" />
