### PR TITLE
feat: rename initialDelay/cooldownWindow to preRunDelay/postRunDelay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Three internal packages, each behind an interface, wired together in `cmd/alerts
 
 - **`internal/alertmanager`** — AlertManager API client. Reads bearer token on every call (handles rotation). TLS via in-cluster CA. Implements `adapter.AlertSource`.
 - **`internal/agenticrun`** — Two concerns: `build.go` translates an alert into an `AgenticRun` CR (deterministic name from alertname, namespace, and startsAt hash; embedded Go template `request.tmpl` for the request field); `client.go` wraps controller-runtime to create/list AgenticRuns. Implements `adapter.AgenticRunClient`.
-- **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `initialDelay` (5m), with an active (non-terminal) AgenticRun, or within `cooldownWindow` (1h) of a terminal AgenticRun. Matching is by `alert-fingerprint` label (stable FNV-64a hash of labels minus configurable ignored labels).
+- **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `preRunDelay` (default 0s), with an active (non-terminal) AgenticRun, or within `postRunDelay` (default 1h) of a terminal AgenticRun. Matching is by `alert-fingerprint` label (stable FNV-64a hash of labels minus configurable ignored labels).
 
 The AgenticRun CRD types come from `github.com/openshift/lightspeed-agentic-operator/api`.
 
@@ -38,6 +38,7 @@ The AgenticRun CRD types come from `github.com/openshift/lightspeed-agentic-oper
 - 409 AlreadyExists on create is expected and handled as a no-op (returns `false, nil`).
 - Stable fingerprint (FNV-64a[:8] of sorted labels minus configurable ignored labels) is used for dedup matching via the `alert-fingerprint` label. Default ignored labels: `pod`, `instance`, `endpoint`, `uid`. Configurable via `deduplication.ignoredLabels` in the ConfigMap. AgenticRun names use a hash of the alert's `startsAt` timestamp for uniqueness.
 - Terminal phases: Completed, Failed, Denied, Escalated.
+- `preRunDelay` (default 0s) and `postRunDelay` (default 1h) are clamped to 0 for zero or negative values. Both can be explicitly set to `0s` to disable the delay. Invalid duration syntax causes a config load error.
 
 ## Conventions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,13 +94,13 @@ every <pollInterval> (default 30s):
     3. For each firing alert:
         a. Receivers not in allowedReceivers?               → skip (not routed to allowed receiver)
         b. Severity is "none" or "info"?                    → skip (low severity)
-        c. now - alert.startsAt < initialDelay?             → skip (too transient)
+        c. now - alert.startsAt < preRunDelay?              → skip (too transient)
         d. Active AgenticRun with same stable fingerprint?    → skip (already handling)
-        e. Terminal AgenticRun within cooldownWindow?       → skip (too soon to retry)
+        e. Terminal AgenticRun within postRunDelay?          → skip (too soon to retry)
         f. Else → CREATE AgenticRun
 ```
 
-**Poll interval**: 30 seconds by default, configurable via ConfigMap. The poll interval is fixed for the lifetime of the process; changes require a pod restart (triggered by the operator). The initial delay dominates response latency, so the poll interval doesn't need to be aggressive.
+**Poll interval**: 30 seconds by default, configurable via ConfigMap. The poll interval is fixed for the lifetime of the process; changes require a pod restart (triggered by the operator). The pre-run delay (when configured) dominates response latency, so the poll interval doesn't need to be aggressive.
 
 The query parameters ensure the adapter only processes alerts that are actively firing and not suppressed by AlertManager's silencing or inhibition rules.
 
@@ -110,8 +110,8 @@ Two configurable parameters control deduplication. Both are configurable via the
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `InitialDelay` | Minimum time an alert must be firing before the adapter creates an AgenticRun. Filters transient alerts that resolve on their own. Uses the alert's `startsAt` field from AlertManager — no in-memory tracking needed. | 5 minutes |
-| `CooldownWindow` | After an AgenticRun reaches a terminal phase (Completed, Failed, Escalated, Denied), minimum time before the adapter creates a new AgenticRun for the same alert (matched by fingerprint label). Prevents flooding for flapping alerts. Uses the terminal AgenticRun's condition timestamps. | 1 hour |
+| `PreRunDelay` | Minimum time an alert must be firing before the adapter creates an AgenticRun. Filters transient alerts that resolve on their own. Uses the alert's `startsAt` field from AlertManager — no in-memory tracking needed. | 0 |
+| `PostRunDelay` | After an AgenticRun reaches a terminal phase (Completed, Failed, Escalated, Denied), minimum time before the adapter creates a new AgenticRun for the same alert (matched by fingerprint label). Avoids repeated analysis of an alert that has already been investigated. Uses the terminal AgenticRun's condition timestamps. | 1 hour |
 
 ### Race Condition Prevention
 
@@ -240,7 +240,7 @@ The adapter uses Go's standard library `log/slog` package with JSON output. Log 
 |-------|-----------------|
 | `Info` | Poll cycle start/end, AgenticRun created (with alert name and namespace), adapter startup/shutdown |
 | `Error` | AlertManager unreachable, Kubernetes API errors, AgenticRun creation failures (non-409) |
-| `Debug` | Alerts skipped due to initial delay, existing AgenticRun, or cooldown window (including the skip reason and alert fingerprint) |
+| `Debug` | Alerts skipped due to pre-run delay, existing AgenticRun, or post-run delay (including the skip reason and alert fingerprint) |
 
 ### Error Handling
 
@@ -364,8 +364,8 @@ The `alerts-adapter-config` ConfigMap is mounted as a volume at `/etc/alerts-ada
 | Field | Default | Description |
 |-------|---------|-------------|
 | `pollInterval` | `30s` | How often to poll AlertManager |
-| `initialDelay` | `5m` | Alert must fire this long before creating an AgenticRun |
-| `cooldownWindow` | `1h` | Minimum time after a terminal AgenticRun before re-proposing for the same alert |
+| `preRunDelay` | `0s` | Alert must fire this long before creating an AgenticRun |
+| `postRunDelay` | `1h` | Minimum time after a terminal AgenticRun before re-proposing for the same alert |
 | `filtering.allowedReceivers` | `[]` | Receiver allowlist — only alerts routed to at least one of these receivers are processed (case-insensitive). Empty by default; no AgenticRuns are created until receivers are explicitly configured |
 | `deduplication.ignoredLabels` | `[pod, instance, endpoint, uid]` | Labels stripped before computing the stable fingerprint for dedup matching. When set, fully replaces the defaults. Set to `[]` to include all labels |
 
@@ -382,7 +382,7 @@ Tools/skills configuration is also supported — see [README.md](README.md#confi
 
 - **AlertManager-aware filtering**: Leverage AlertManager's grouping features to reduce noise. The adapter already filters out silenced and inhibited alerts via query parameters, but does not use grouping metadata. Future iterations could create a single AgenticRun per alert group instead of per individual alert.
 - **Custom fingerprinting and alert grouping**: Consider replacing AlertManager's fingerprint (hash of all labels) with a custom fingerprint computed from a chosen subset of labels. This could potentially enable custom alert grouping to handle alert storms — e.g., multiple related alerts might map to a single AgenticRun instead of creating one per alert. A custom fingerprint would also decouple the adapter from AlertManager's fingerprint format, making it easier to switch to other alert sources (e.g., Thanos Ruler) in the future. To be evaluated based on real-world usage patterns.
-- **Per-alert-group configuration**: Allow a configuration resource (ConfigMap or CRD) to define customized settings per alert group — including initial delay, cooldown window, workflow pattern (full remediation / advisory / assisted), and prompt template. This would enable different handling strategies for different classes of alerts (e.g., shorter delay for critical infrastructure alerts, advisory-only for capacity warnings).
+- **Per-alert-group configuration**: Allow a configuration resource (ConfigMap or CRD) to define customized settings per alert group — including pre-run delay, post-run delay, workflow pattern (full remediation / advisory / assisted), and prompt template. This would enable different handling strategies for different classes of alerts (e.g., shorter delay for critical infrastructure alerts, advisory-only for capacity warnings).
 - **Label-selector alert filtering**: The adapter currently filters by receiver allowlist and severity. A future iteration could add configurable label selectors for more fine-grained alert filtering.
 - **Prometheus metrics**: `alerts_adapter_polls_total`, `agenticruns_created_total`, `errors_total`, `poll_duration_seconds`.
 - **Adapter-specific analysis output schema**: Inject custom fields into `analysisOutput.schema` for alert correlation, affected services topology.

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ The adapter runs as a single-replica Deployment in the `openshift-lightspeed` na
 
 ### ConfigMap
 
-Runtime-tunable parameters are read from the `alerts-adapter-config` ConfigMap in the `openshift-lightspeed` namespace (key: `config.yaml`). Changes are picked up on the next poll cycle — no restart required. If the ConfigMap is missing or malformed, defaults are used.
+Runtime-tunable parameters are read from the `alerts-adapter-config` ConfigMap in the `openshift-lightspeed` namespace (key: `config.yaml`), mounted as a volume and read once at startup. The operator restarts the adapter pod when the ConfigMap changes. If the ConfigMap is missing, defaults are used. Invalid YAML or unparseable duration values cause the adapter to fail to start.
 
 | Field | Default | Description |
 |---|---|---|
 | `pollInterval` | `30s` | How often to poll AlertManager |
-| `initialDelay` | `5m` | Minimum time an alert must fire before an AgenticRun is created |
-| `cooldownWindow` | `1h` | Minimum time after a terminal AgenticRun before retrying the same alert |
+| `preRunDelay` | `0s` | Minimum time an alert must fire before an AgenticRun is created |
+| `postRunDelay` | `1h` | Minimum time after a terminal AgenticRun before retrying the same alert |
 | `filtering.allowedReceivers` | `[]` | Receiver allowlist — only alerts routed to at least one of these receivers are processed (case-insensitive). Empty by default; no AgenticRuns are created until receivers are explicitly configured |
 | `deduplication.ignoredLabels` | `[pod, instance, endpoint, uid]` | Labels stripped before computing the stable fingerprint for dedup matching. When set, fully replaces the defaults. Set to `[]` to include all labels |
 
@@ -89,8 +89,8 @@ metadata:
 data:
   config.yaml: |
     pollInterval: "45s"
-    initialDelay: "10m"
-    cooldownWindow: "2h"
+    preRunDelay: "10m"
+    postRunDelay: "2h"
     filtering:
       allowedReceivers:
         - critical

--- a/cmd/alerts-adapter/main.go
+++ b/cmd/alerts-adapter/main.go
@@ -28,7 +28,11 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	cfg := config.LoadFromFile(config.DefaultConfigPath, logger)
+	cfg, err := config.LoadFromFile(config.DefaultConfigPath, logger)
+	if err != nil {
+		logger.Error("fatal error", "error", err)
+		os.Exit(1)
+	}
 
 	amClient, err := alertmanager.New(alertmanager.Config{
 		URL: os.Getenv("ALERTMANAGER_URL"),

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -29,8 +29,8 @@ type AgenticRunClient interface {
 }
 
 // Adapter polls AlertManager for firing alerts and creates AgenticRun CRs,
-// applying stateless deduplication (initial delay, active-run check,
-// and cooldown window) on each cycle.
+// applying stateless deduplication (pre-run delay, active-run check,
+// and post-run delay) on each cycle.
 type Adapter struct {
 	alerts   AlertSource
 	arClient AgenticRunClient
@@ -53,8 +53,8 @@ func New(alerts AlertSource, arClient AgenticRunClient, cfg config.Config, logge
 func (a *Adapter) Run(ctx context.Context) error {
 	a.logger.Info("adapter started",
 		"pollInterval", a.cfg.PollInterval.String(),
-		"initialDelay", a.cfg.InitialDelay.String(),
-		"cooldownWindow", a.cfg.CooldownWindow.String(),
+		"preRunDelay", a.cfg.PreRunDelay.String(),
+		"postRunDelay", a.cfg.PostRunDelay.String(),
 		"allowedReceivers", a.cfg.AllowedReceivers,
 	)
 
@@ -125,12 +125,12 @@ func (a *Adapter) reconcile(ctx context.Context) {
 			continue
 		}
 
-		if skipInitialDelay(alert, now, a.cfg.InitialDelay) {
-			a.logger.Debug("alert skipped: initial delay",
+		if a.cfg.PreRunDelay > 0 && tooEarly(alert, now, a.cfg.PreRunDelay) {
+			a.logger.Debug("alert skipped: pre-run delay",
 				"alertname", alertName,
 				"fingerprint", fingerprint,
 				"startsAt", alert.StartsAt,
-				"threshold", a.cfg.InitialDelay,
+				"preRunDelay", a.cfg.PreRunDelay,
 			)
 			skipped++
 			continue
@@ -147,11 +147,11 @@ func (a *Adapter) reconcile(ctx context.Context) {
 			continue
 		}
 
-		if inCooldown(stableFP, runs, now, a.cfg.CooldownWindow) {
-			a.logger.Debug("alert skipped: cooldown window",
+		if a.cfg.PostRunDelay > 0 && tooRecent(stableFP, runs, now, a.cfg.PostRunDelay) {
+			a.logger.Debug("alert skipped: post-run delay",
 				"alertname", alertName,
 				"fingerprint", fingerprint,
-				"cooldown", a.cfg.CooldownWindow,
+				"postRunDelay", a.cfg.PostRunDelay,
 			)
 			skipped++
 			continue
@@ -223,7 +223,7 @@ func skipSeverity(alert *models.GettableAlert) bool {
 	return sev == "none" || sev == "info"
 }
 
-func skipInitialDelay(alert *models.GettableAlert, now time.Time, threshold time.Duration) bool {
+func tooEarly(alert *models.GettableAlert, now time.Time, threshold time.Duration) bool {
 	if alert.StartsAt == nil {
 		return true
 	}
@@ -243,7 +243,7 @@ func hasActiveRun(stableFingerprint string, runs []agenticv1alpha1.AgenticRun) b
 	return false
 }
 
-func inCooldown(stableFingerprint string, runs []agenticv1alpha1.AgenticRun, now time.Time, window time.Duration) bool {
+func tooRecent(stableFingerprint string, runs []agenticv1alpha1.AgenticRun, now time.Time, window time.Duration) bool {
 	for i := range runs {
 		if runs[i].Labels["agentic.openshift.io/alert-fingerprint"] != stableFingerprint {
 			continue

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -60,8 +60,8 @@ func ptr[T any](v T) *T { return &v }
 func defaultTestConfig() config.Config {
 	return config.Config{
 		PollInterval:     config.DefaultPollInterval,
-		InitialDelay:     config.DefaultInitialDelay,
-		CooldownWindow:   config.DefaultCooldownWindow,
+		PreRunDelay:      5 * time.Minute,
+		PostRunDelay:     1 * time.Hour,
 		AllowedReceivers: []string{"critical"},
 		IgnoredLabels:    config.DefaultIgnoredLabels,
 	}
@@ -112,8 +112,8 @@ func TestReconcile(t *testing.T) {
 	now := time.Now()
 	oldEnough := now.Add(-10 * time.Minute)
 	tooRecent := now.Add(-2 * time.Minute)
-	withinCooldown := now.Add(-30 * time.Minute)
-	pastCooldown := now.Add(-2 * time.Hour)
+	withinPostDelay := now.Add(-30 * time.Minute)
+	pastPostDelay := now.Add(-2 * time.Hour)
 
 	highCPUFP := stableFP(models.LabelSet{"alertname": "HighCPU", "severity": "warning"})
 
@@ -135,7 +135,7 @@ func TestReconcile(t *testing.T) {
 			wantCreateCalls: 1,
 		},
 		{
-			name:        "transient alert skipped (initial delay)",
+			name:        "transient alert skipped (pre-run delay)",
 			alerts:      models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", tooRecent)},
 			wantCreated: 0,
 		},
@@ -150,7 +150,7 @@ func TestReconcile(t *testing.T) {
 			wantCreated: 0,
 		},
 		{
-			name:   "terminal run within cooldown skipped",
+			name:   "terminal run within post-run delay skipped",
 			alerts: models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", oldEnough)},
 			runs: []agenticv1alpha1.AgenticRun{
 				makeRun(highCPUFP, []metav1.Condition{
@@ -159,14 +159,14 @@ func TestReconcile(t *testing.T) {
 					{
 						Type:               "Verified",
 						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(withinCooldown),
+						LastTransitionTime: metav1.NewTime(withinPostDelay),
 					},
 				}),
 			},
 			wantCreated: 0,
 		},
 		{
-			name:   "terminal run past cooldown creates new run",
+			name:   "terminal run past post-run delay creates new run",
 			alerts: models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", oldEnough)},
 			runs: []agenticv1alpha1.AgenticRun{
 				makeRun(highCPUFP, []metav1.Condition{
@@ -175,7 +175,7 @@ func TestReconcile(t *testing.T) {
 					{
 						Type:               "Verified",
 						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(pastCooldown),
+						LastTransitionTime: metav1.NewTime(pastPostDelay),
 					},
 				}),
 			},
@@ -183,42 +183,42 @@ func TestReconcile(t *testing.T) {
 			wantCreateCalls: 1,
 		},
 		{
-			name:   "failed run within cooldown skipped",
+			name:   "failed run within post-run delay skipped",
 			alerts: models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", oldEnough)},
 			runs: []agenticv1alpha1.AgenticRun{
 				makeRun(highCPUFP, []metav1.Condition{
 					{
 						Type:               "Analyzed",
 						Status:             metav1.ConditionFalse,
-						LastTransitionTime: metav1.NewTime(withinCooldown),
+						LastTransitionTime: metav1.NewTime(withinPostDelay),
 					},
 				}),
 			},
 			wantCreated: 0,
 		},
 		{
-			name:   "denied run within cooldown skipped",
+			name:   "denied run within post-run delay skipped",
 			alerts: models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", oldEnough)},
 			runs: []agenticv1alpha1.AgenticRun{
 				makeRun(highCPUFP, []metav1.Condition{
 					{
 						Type:               "Denied",
 						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(withinCooldown),
+						LastTransitionTime: metav1.NewTime(withinPostDelay),
 					},
 				}),
 			},
 			wantCreated: 0,
 		},
 		{
-			name:   "escalated run within cooldown skipped",
+			name:   "escalated run within post-run delay skipped",
 			alerts: models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", oldEnough)},
 			runs: []agenticv1alpha1.AgenticRun{
 				makeRun(highCPUFP, []metav1.Condition{
 					{
 						Type:               "Escalated",
 						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(withinCooldown),
+						LastTransitionTime: metav1.NewTime(withinPostDelay),
 					},
 				}),
 			},
@@ -549,6 +549,60 @@ func TestReconcileWithTools(t *testing.T) {
 			t.Errorf("expected zero verification.tools, got %+v", p.Spec.Verification.Tools)
 		}
 	})
+}
+
+func TestReconcileZeroDelays(t *testing.T) {
+	now := time.Now()
+	justStarted := now.Add(-1 * time.Second)
+	recentTerminal := now.Add(-1 * time.Minute)
+
+	highCPUFP := stableFP(models.LabelSet{"alertname": "HighCPU", "severity": "warning"})
+
+	tests := []struct {
+		name         string
+		preRunDelay  time.Duration
+		postRunDelay time.Duration
+		alerts       models.GettableAlerts
+		runs         []agenticv1alpha1.AgenticRun
+	}{
+		{
+			name:         "zero preRunDelay skips the delay check",
+			preRunDelay:  0,
+			postRunDelay: 1 * time.Hour,
+			alerts:       models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", justStarted)},
+		},
+		{
+			name:         "zero postRunDelay skips the delay check",
+			preRunDelay:  5 * time.Minute,
+			postRunDelay: 0,
+			alerts:       models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", now.Add(-10*time.Minute))},
+			runs: []agenticv1alpha1.AgenticRun{
+				makeRun(highCPUFP, []metav1.Condition{
+					{Type: "Analyzed", Status: metav1.ConditionTrue},
+					{Type: "Executed", Status: metav1.ConditionTrue},
+					{Type: "Verified", Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(recentTerminal)},
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as := &fakeAlertSource{alerts: tt.alerts}
+			rc := &fakeRunClient{runs: tt.runs}
+
+			cfg := defaultTestConfig()
+			cfg.PreRunDelay = tt.preRunDelay
+			cfg.PostRunDelay = tt.postRunDelay
+
+			a := &Adapter{alerts: as, arClient: rc, cfg: cfg, logger: quietLogger()}
+			a.reconcile(context.Background())
+
+			if rc.createCalls != 1 {
+				t.Errorf("CreateAgenticRun called %d times, want 1 (zero delay should not skip)", rc.createCalls)
+			}
+		})
+	}
 }
 
 func TestReconcileDedupsWithinSameCycle(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	DefaultPollInterval   = 30 * time.Second
-	DefaultInitialDelay   = 5 * time.Minute
-	DefaultCooldownWindow = 1 * time.Hour
+	DefaultPollInterval  = 30 * time.Second
+	DefaultPreRunDelay   = 0
+	DefaultPostRunDelay  = 1 * time.Hour
 
 	DefaultConfigPath = "/etc/alerts-adapter/config.yaml"
 )
@@ -39,9 +39,9 @@ type ToolsConfig struct {
 
 // Config holds the adapter's runtime-tunable parameters.
 type Config struct {
-	PollInterval     time.Duration
-	InitialDelay     time.Duration
-	CooldownWindow   time.Duration
+	PollInterval    time.Duration
+	PreRunDelay     time.Duration
+	PostRunDelay    time.Duration
 	AllowedReceivers []string
 	IgnoredLabels    []string
 	Tools            ToolsConfig
@@ -51,9 +51,9 @@ type Config struct {
 // Default returns a Config with the default values.
 func Default() Config {
 	return Config{
-		PollInterval:     DefaultPollInterval,
-		InitialDelay:     DefaultInitialDelay,
-		CooldownWindow:   DefaultCooldownWindow,
+		PollInterval:    DefaultPollInterval,
+		PreRunDelay:     DefaultPreRunDelay,
+		PostRunDelay:    DefaultPostRunDelay,
 		AllowedReceivers: nil,
 		IgnoredLabels:    append([]string{}, DefaultIgnoredLabels...),
 	}
@@ -61,8 +61,8 @@ func Default() Config {
 
 type configFile struct {
 	PollInterval     Duration         `yaml:"pollInterval"`
-	InitialDelay     Duration         `yaml:"initialDelay"`
-	CooldownWindow   Duration         `yaml:"cooldownWindow"`
+	PreRunDelay      Duration         `yaml:"preRunDelay"`
+	PostRunDelay     Duration         `yaml:"postRunDelay"`
 	AllowedReceivers *[]string        `yaml:"allowedReceivers"`
 	Filtering        filteringEntry   `yaml:"filtering"`
 	Deduplication    deduplicationEntry `yaml:"deduplication"`
@@ -122,20 +122,23 @@ func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
 }
 
 // LoadFromFile reads configuration from a YAML file at the given path.
-// It never returns an error — on any failure it falls back to defaults and logs.
-func LoadFromFile(path string, logger *slog.Logger) Config {
+// It returns an error on invalid YAML or unparseable duration values.
+// Missing file is not an error — defaults are used.
+func LoadFromFile(path string, logger *slog.Logger) (Config, error) {
 	cfg := Default()
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		logger.Error("failed to read config file, using defaults", "path", path, "error", err)
-		return cfg
+		if os.IsNotExist(err) {
+			logger.Info("config file not found, using defaults", "path", path)
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("reading config file: %w", err)
 	}
 
 	var cf configFile
 	if err := yaml.Unmarshal(data, &cf); err != nil {
-		logger.Error("failed to parse config file, using defaults", "path", path, "error", err)
-		return cfg
+		return cfg, fmt.Errorf("parsing config file: %w", err)
 	}
 
 	if cf.PollInterval.isSet {
@@ -145,18 +148,18 @@ func LoadFromFile(path string, logger *slog.Logger) Config {
 			logger.Error("pollInterval must be positive, using default", "value", cf.PollInterval.Duration)
 		}
 	}
-	if cf.InitialDelay.isSet {
-		if cf.InitialDelay.Duration > 0 {
-			cfg.InitialDelay = cf.InitialDelay.Duration
+	if cf.PreRunDelay.isSet {
+		if cf.PreRunDelay.Duration > 0 {
+			cfg.PreRunDelay = cf.PreRunDelay.Duration
 		} else {
-			logger.Error("initialDelay must be positive, using default", "value", cf.InitialDelay.Duration)
+			cfg.PreRunDelay = 0
 		}
 	}
-	if cf.CooldownWindow.isSet {
-		if cf.CooldownWindow.Duration > 0 {
-			cfg.CooldownWindow = cf.CooldownWindow.Duration
+	if cf.PostRunDelay.isSet {
+		if cf.PostRunDelay.Duration > 0 {
+			cfg.PostRunDelay = cf.PostRunDelay.Duration
 		} else {
-			logger.Error("cooldownWindow must be positive, using default", "value", cf.CooldownWindow.Duration)
+			cfg.PostRunDelay = 0
 		}
 	}
 
@@ -190,7 +193,7 @@ func LoadFromFile(path string, logger *slog.Logger) Config {
 		Verification: cf.Agent.Verification,
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 func parseSkills(entries []skillsEntry, step string, logger *slog.Logger) []agenticv1alpha1.SkillsSource {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,46 +27,46 @@ func writeConfigFile(t *testing.T, content string) string {
 
 func TestLoadFromFile(t *testing.T) {
 	tests := []struct {
-		name               string
-		yaml               string
-		wantPollInterval   time.Duration
-		wantInitialDelay   time.Duration
-		wantCooldownWindow time.Duration
+		name             string
+		yaml             string
+		wantPollInterval time.Duration
+		wantPreRunDelay  time.Duration
+		wantPostRunDelay time.Duration
 	}{
 		{
-			name:               "valid full config",
-			yaml:               "pollInterval: 45s\ninitialDelay: 10m\ncooldownWindow: 30m\n",
-			wantPollInterval:   45 * time.Second,
-			wantInitialDelay:   10 * time.Minute,
-			wantCooldownWindow: 30 * time.Minute,
+			name:             "valid full config",
+			yaml:             "pollInterval: 45s\npreRunDelay: 10m\npostRunDelay: 30m\n",
+			wantPollInterval: 45 * time.Second,
+			wantPreRunDelay:  10 * time.Minute,
+			wantPostRunDelay: 30 * time.Minute,
 		},
 		{
-			name:               "partial config - only poll interval",
-			yaml:               "pollInterval: 1m\n",
-			wantPollInterval:   time.Minute,
-			wantInitialDelay:   DefaultInitialDelay,
-			wantCooldownWindow: DefaultCooldownWindow,
+			name:             "partial config - only poll interval",
+			yaml:             "pollInterval: 1m\n",
+			wantPollInterval: time.Minute,
+			wantPreRunDelay:  DefaultPreRunDelay,
+			wantPostRunDelay: DefaultPostRunDelay,
 		},
 		{
-			name:               "partial config - only cooldown window",
-			yaml:               "cooldownWindow: 2h\n",
-			wantPollInterval:   DefaultPollInterval,
-			wantInitialDelay:   DefaultInitialDelay,
-			wantCooldownWindow: 2 * time.Hour,
+			name:             "partial config - only postRunDelay",
+			yaml:             "postRunDelay: 2h\n",
+			wantPollInterval: DefaultPollInterval,
+			wantPreRunDelay:  DefaultPreRunDelay,
+			wantPostRunDelay: 2 * time.Hour,
 		},
 		{
-			name:               "empty yaml",
-			yaml:               "",
-			wantPollInterval:   DefaultPollInterval,
-			wantInitialDelay:   DefaultInitialDelay,
-			wantCooldownWindow: DefaultCooldownWindow,
+			name:             "empty yaml",
+			yaml:             "",
+			wantPollInterval: DefaultPollInterval,
+			wantPreRunDelay:  DefaultPreRunDelay,
+			wantPostRunDelay: DefaultPostRunDelay,
 		},
 		{
-			name:               "empty document",
-			yaml:               "---\n",
-			wantPollInterval:   DefaultPollInterval,
-			wantInitialDelay:   DefaultInitialDelay,
-			wantCooldownWindow: DefaultCooldownWindow,
+			name:             "empty document",
+			yaml:             "---\n",
+			wantPollInterval: DefaultPollInterval,
+			wantPreRunDelay:  DefaultPreRunDelay,
+			wantPostRunDelay: DefaultPostRunDelay,
 		},
 	}
 
@@ -74,16 +74,19 @@ func TestLoadFromFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
+			cfg, err := LoadFromFile(path, quietLogger())
+			if err != nil {
+				t.Fatalf("LoadFromFile() error = %v", err)
+			}
 
 			if cfg.PollInterval != tt.wantPollInterval {
 				t.Errorf("PollInterval = %v, want %v", cfg.PollInterval, tt.wantPollInterval)
 			}
-			if cfg.InitialDelay != tt.wantInitialDelay {
-				t.Errorf("InitialDelay = %v, want %v", cfg.InitialDelay, tt.wantInitialDelay)
+			if cfg.PreRunDelay != tt.wantPreRunDelay {
+				t.Errorf("PreRunDelay = %v, want %v", cfg.PreRunDelay, tt.wantPreRunDelay)
 			}
-			if cfg.CooldownWindow != tt.wantCooldownWindow {
-				t.Errorf("CooldownWindow = %v, want %v", cfg.CooldownWindow, tt.wantCooldownWindow)
+			if cfg.PostRunDelay != tt.wantPostRunDelay {
+				t.Errorf("PostRunDelay = %v, want %v", cfg.PostRunDelay, tt.wantPostRunDelay)
 			}
 		})
 	}
@@ -96,45 +99,69 @@ func TestLoadFromFileInvalid(t *testing.T) {
 	}{
 		{
 			name: "invalid yaml",
-			yaml: ":::not yaml:::",
+			yaml: "key: [unclosed bracket",
 		},
 		{
 			name: "invalid duration value",
 			yaml: "pollInterval: not-a-duration\n",
 		},
+		{
+			name: "invalid preRunDelay",
+			yaml: "preRunDelay: abc\n",
+		},
+		{
+			name: "invalid postRunDelay",
+			yaml: "postRunDelay: xyz\n",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
-
-			assertDefaults(t, cfg)
+			_, err := LoadFromFile(path, quietLogger())
+			if err == nil {
+				t.Fatal("LoadFromFile() expected error, got nil")
+			}
 		})
 	}
 }
 
-func TestNonPositiveDurationsFallBackToDefaults(t *testing.T) {
+func TestNonPositiveDurationsClampToZero(t *testing.T) {
 	tests := []struct {
-		name string
-		yaml string
+		name             string
+		yaml             string
+		wantPollInterval time.Duration
+		wantPreRunDelay  time.Duration
+		wantPostRunDelay time.Duration
 	}{
 		{
-			name: "zero poll interval",
-			yaml: "pollInterval: 0s",
+			name:             "zero poll interval falls back to default",
+			yaml:             "pollInterval: 0s",
+			wantPollInterval: DefaultPollInterval,
+			wantPreRunDelay:  DefaultPreRunDelay,
+			wantPostRunDelay: DefaultPostRunDelay,
 		},
 		{
-			name: "negative initial delay",
-			yaml: "initialDelay: -5m",
+			name:             "negative preRunDelay clamped to 0",
+			yaml:             "preRunDelay: -5m",
+			wantPollInterval: DefaultPollInterval,
+			wantPreRunDelay:  0,
+			wantPostRunDelay: DefaultPostRunDelay,
 		},
 		{
-			name: "negative cooldown window",
-			yaml: "cooldownWindow: -1h",
+			name:             "negative postRunDelay clamped to 0",
+			yaml:             "postRunDelay: -1h",
+			wantPollInterval: DefaultPollInterval,
+			wantPreRunDelay:  DefaultPreRunDelay,
+			wantPostRunDelay: 0,
 		},
 		{
-			name: "all zero",
-			yaml: "pollInterval: 0s\ninitialDelay: 0s\ncooldownWindow: 0s",
+			name:             "explicit zero preRunDelay and postRunDelay override defaults",
+			yaml:             "preRunDelay: 0s\npostRunDelay: 0s",
+			wantPollInterval: DefaultPollInterval,
+			wantPreRunDelay:  0,
+			wantPostRunDelay: 0,
 		},
 	}
 
@@ -142,15 +169,29 @@ func TestNonPositiveDurationsFallBackToDefaults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
+			cfg, err := LoadFromFile(path, quietLogger())
+			if err != nil {
+				t.Fatalf("LoadFromFile() error = %v", err)
+			}
 
-			assertDefaults(t, cfg)
+			if cfg.PollInterval != tt.wantPollInterval {
+				t.Errorf("PollInterval = %v, want %v", cfg.PollInterval, tt.wantPollInterval)
+			}
+			if cfg.PreRunDelay != tt.wantPreRunDelay {
+				t.Errorf("PreRunDelay = %v, want %v", cfg.PreRunDelay, tt.wantPreRunDelay)
+			}
+			if cfg.PostRunDelay != tt.wantPostRunDelay {
+				t.Errorf("PostRunDelay = %v, want %v", cfg.PostRunDelay, tt.wantPostRunDelay)
+			}
 		})
 	}
 }
 
 func TestLoadFromFileMissing(t *testing.T) {
-	cfg := LoadFromFile("/nonexistent/path/config.yaml", quietLogger())
+	cfg, err := LoadFromFile("/nonexistent/path/config.yaml", quietLogger())
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
 
 	assertDefaults(t, cfg)
 }
@@ -161,11 +202,11 @@ func assertDefaults(t *testing.T, cfg Config) {
 	if cfg.PollInterval != defaults.PollInterval {
 		t.Errorf("PollInterval = %v, want %v", cfg.PollInterval, defaults.PollInterval)
 	}
-	if cfg.InitialDelay != defaults.InitialDelay {
-		t.Errorf("InitialDelay = %v, want %v", cfg.InitialDelay, defaults.InitialDelay)
+	if cfg.PreRunDelay != defaults.PreRunDelay {
+		t.Errorf("PreRunDelay = %v, want %v", cfg.PreRunDelay, defaults.PreRunDelay)
 	}
-	if cfg.CooldownWindow != defaults.CooldownWindow {
-		t.Errorf("CooldownWindow = %v, want %v", cfg.CooldownWindow, defaults.CooldownWindow)
+	if cfg.PostRunDelay != defaults.PostRunDelay {
+		t.Errorf("PostRunDelay = %v, want %v", cfg.PostRunDelay, defaults.PostRunDelay)
 	}
 	assertReceiversEqual(t, cfg.AllowedReceivers, defaults.AllowedReceivers)
 	assertStringSliceEqual(t, "IgnoredLabels", cfg.IgnoredLabels, DefaultIgnoredLabels)
@@ -360,7 +401,10 @@ execution:
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
+			cfg, err := LoadFromFile(path, quietLogger())
+			if err != nil {
+				t.Fatalf("LoadFromFile() error = %v", err)
+			}
 
 			assertSkillsEqual(t, "Tools.Shared", cfg.Tools.Shared, tt.wantTools.Shared)
 			assertSkillsEqual(t, "Tools.Analysis", cfg.Tools.Analysis, tt.wantTools.Analysis)
@@ -407,7 +451,10 @@ func TestParseAllowedReceivers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
+			cfg, err := LoadFromFile(path, quietLogger())
+			if err != nil {
+				t.Fatalf("LoadFromFile() error = %v", err)
+			}
 
 			assertReceiversEqual(t, cfg.AllowedReceivers, tt.want)
 		})
@@ -441,7 +488,10 @@ func TestParseIgnoredLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
+			cfg, err := LoadFromFile(path, quietLogger())
+			if err != nil {
+				t.Fatalf("LoadFromFile() error = %v", err)
+			}
 
 			assertStringSliceEqual(t, "IgnoredLabels", cfg.IgnoredLabels, tt.want)
 		})
@@ -480,7 +530,10 @@ func TestParseFilteringAllowedReceivers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
+			cfg, err := LoadFromFile(path, quietLogger())
+			if err != nil {
+				t.Fatalf("LoadFromFile() error = %v", err)
+			}
 
 			assertReceiversEqual(t, cfg.AllowedReceivers, tt.want)
 		})
@@ -488,7 +541,10 @@ func TestParseFilteringAllowedReceivers(t *testing.T) {
 }
 
 func TestAllowedReceiversDefaultsOnMissingFile(t *testing.T) {
-	cfg := LoadFromFile("/nonexistent/path/config.yaml", quietLogger())
+	cfg, err := LoadFromFile("/nonexistent/path/config.yaml", quietLogger())
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
 
 	assertReceiversEqual(t, cfg.AllowedReceivers, nil)
 }
@@ -581,7 +637,10 @@ agent:
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeConfigFile(t, tt.yaml)
 
-			cfg := LoadFromFile(path, quietLogger())
+			cfg, err := LoadFromFile(path, quietLogger())
+			if err != nil {
+				t.Fatalf("LoadFromFile() error = %v", err)
+			}
 
 			if cfg.Agent != tt.wantAgent {
 				t.Errorf("Agent = %+v, want %+v", cfg.Agent, tt.wantAgent)

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -9,16 +9,17 @@ data:
     # Default: 30s
     pollInterval: 30s
 
-    # initialDelay: how long an alert must be firing before an AgenticRun is created.
+    # preRunDelay: how long an alert must be firing before an AgenticRun is created.
     # Filters out transient alerts that resolve on their own.
-    # Default: 5m
-    initialDelay: 5m
+    # Default: 0s (no delay)
+    # preRunDelay: 5m
 
-    # cooldownWindow: after an AgenticRun reaches a terminal state (Completed, Failed,
+    # postRunDelay: after an AgenticRun reaches a terminal state (Completed, Failed,
     # Denied, Escalated), how long to wait before creating a new AgenticRun for the
-    # same alert (matched by stable fingerprint label). Prevents flooding for flapping alerts.
+    # same alert (matched by stable fingerprint label). Avoids repeated analysis of
+    # an alert that has already been investigated.
     # Default: 1h
-    cooldownWindow: 1h
+    postRunDelay: 1h
 
     # filtering: controls which alerts the adapter processes.
     filtering:

--- a/openspec/changes/archive/2026-07-21-rename-delay-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-21-rename-delay-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/archive/2026-07-21-rename-delay-config/design.md
+++ b/openspec/changes/archive/2026-07-21-rename-delay-config/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The adapter uses two duration-based config fields to gate AgenticRun creation: `initialDelay` (wait before acting on a new alert) and `cooldownWindow` (wait before re-acting after a terminal AgenticRun). Both names are vague. This change renames them to `preRunDelay` and `postRunDelay`, defaults `preRunDelay` to 0s (act immediately on new alerts) and `postRunDelay` to 1h (avoid repeated analysis), and allows explicit `0s` to disable either delay.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename `initialDelay` to `preRunDelay` and `cooldownWindow` to `postRunDelay` across Go code, config YAML, docs, and manifests
+- Default `preRunDelay` to 0s and `postRunDelay` to 1h when not set in the ConfigMap
+- Allow explicit `0s` to disable either delay (distinguish "not set" from "set to 0")
+- Clamp negative values to 0s silently (no error log)
+
+**Non-Goals:**
+- Backward compatibility with old key names (clean break)
+- Changing the semantics of what these delays do (only names and defaults change)
+- Changing pollInterval defaults or behavior
+
+## Decisions
+
+**Rename Go identifiers to match new YAML keys**
+
+Rename `Config.InitialDelay` to `Config.PreRunDelay`, `DefaultInitialDelay` to `DefaultPreRunDelay`, `skipInitialDelay()` to `tooEarly()`, and similarly for the cooldown side: `Config.CooldownWindow` to `Config.PostRunDelay`, `DefaultCooldownWindow` to `DefaultPostRunDelay`. The helper `inCooldown()` becomes `tooRecent()`. These names describe what the check answers rather than the mechanism.
+
+Alternative considered: keeping the old Go identifiers and only changing the YAML keys. Rejected because split naming creates confusion between code and config.
+
+**Default `preRunDelay` to 0s, `postRunDelay` to 1h**
+
+`DefaultPreRunDelay = 0` and `DefaultPostRunDelay = 1 * time.Hour`. The pre-run delay defaults to 0 so the adapter acts immediately on new alerts. The post-run delay defaults to 1h to avoid repeated analysis of an alert that has already been investigated. Both can be explicitly set to `0s` in the ConfigMap to disable the delay.
+
+**Distinguish "not set" from "explicit 0" using `Duration.isSet`**
+
+The `Duration` type's `isSet` flag tracks whether a key was present in YAML. When `isSet` is true and the value is zero or negative, the config is set to 0 (overriding the default). When `isSet` is false, the default is kept. Negative values are clamped to 0 silently.
+
+**Fail hard on invalid syntax**
+
+If a duration string cannot be parsed (e.g., `preRunDelay: "abc"`), `LoadFromFile` returns an error. The reconcile loop propagates this error, logging it and skipping the cycle. This is a change from the current behavior, which silently falls back to defaults. Rationale: a typo in config should be visible immediately, not masked by a silent fallback that changes operational behavior.
+
+**No backward compatibility shim**
+
+Old ConfigMaps using `initialDelay` or `cooldownWindow` will be silently ignored (treated as unrecognized keys by strict YAML parsing). This is acceptable because the adapter is pre-GA and the ConfigMap is deployed alongside it.
+
+## Risks / Trade-offs
+
+**Existing deployments break silently** - A deployment with `initialDelay: 10m` or `cooldownWindow: 2h` in its ConfigMap will lose those settings after upgrade. `preRunDelay` will default to 0s (act immediately) and `postRunDelay` will default to 1h. Mitigation: release notes must call this out.

--- a/openspec/changes/archive/2026-07-21-rename-delay-config/proposal.md
+++ b/openspec/changes/archive/2026-07-21-rename-delay-config/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The names `initialDelay` and `cooldownWindow` are vague and inconsistent. `preRunDelay` and `postRunDelay` clearly communicate their relationship to the AgenticRun lifecycle: `preRunDelay` prevents an AgenticRun from being created until the alert has been firing for a minimum time, filtering out transient alerts that resolve on their own. `postRunDelay` prevents a new AgenticRun from being created when the alert is still firing after a previous run has finished, avoiding repeated analysis of an alert that has already been investigated. The `preRunDelay` default changes from 5m to 0s so the adapter acts immediately on new alerts. The `postRunDelay` default stays at 1h to avoid repeated analysis of an alert that has already been investigated. Both can be explicitly set to `0s` to disable the delay.
+
+## What Changes
+
+- **BREAKING**: Rename ConfigMap key `initialDelay` to `preRunDelay`
+- **BREAKING**: Rename ConfigMap key `cooldownWindow` to `postRunDelay`
+- Change default for `preRunDelay` from 5m to 0s (act immediately on new alerts)
+- Keep default for `postRunDelay` at 1h (avoid repeated analysis of an alert that has already been investigated)
+- Allow explicit `0s` to disable either delay (distinguishes "not set" from "set to 0")
+- Negative values are clamped to 0s silently
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `configmap-config`: Rename `initialDelay`/`cooldownWindow` keys to `preRunDelay`/`postRunDelay`, default `preRunDelay` to 0s and `postRunDelay` to 1h, allow explicit 0s to disable delays
+- `poll-loop`: Update references to use the renamed config fields; adapt dedup logic to handle 0s delays (skip the check entirely when delay is 0)
+
+## Impact
+
+- **Config**: Go struct fields, constants, YAML keys, and validation logic in `internal/config/`
+- **Adapter**: References in `internal/adapter/` (field access, helper functions, log messages)
+- **Docs**: README.md, ARCHITECTURE.md, AGENTS.md, manifests/configmap.yaml
+- **Tests**: All tests referencing the old names or old defaults
+- **Breaking**: Any existing ConfigMap using `initialDelay` or `cooldownWindow` will need to be updated

--- a/openspec/changes/archive/2026-07-21-rename-delay-config/specs/configmap-config/spec.md
+++ b/openspec/changes/archive/2026-07-21-rename-delay-config/specs/configmap-config/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: Use well-defined default values
+The system SHALL use the following default values when no ConfigMap is present or when individual fields are missing:
+- `pollInterval`: 30 seconds
+- `preRunDelay`: 0 seconds
+- `postRunDelay`: 1 hour
+- `allowedReceivers`: empty list (no alerts are processed until explicitly configured)
+
+#### Scenario: All defaults applied
+- **WHEN** no ConfigMap exists
+- **THEN** the system uses `pollInterval=30s`, `preRunDelay=0s`, `postRunDelay=1h`, `allowedReceivers=[]`
+
+### Requirement: Load configuration from a ConfigMap each reconcile cycle
+The system SHALL read the `alerts-adapter-config` ConfigMap from the adapter's namespace on each reconcile cycle and apply the configuration values for that cycle.
+
+#### Scenario: ConfigMap exists with valid YAML
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains valid YAML with valid duration values
+- **THEN** the system uses the values from the ConfigMap for that reconcile cycle
+
+#### Scenario: ConfigMap exists with partial YAML
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains valid YAML with only some fields specified
+- **THEN** the system uses the specified values and falls back to defaults for missing fields
+
+#### Scenario: ConfigMap exists with invalid duration value
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains an unparseable duration string for one or more fields
+- **THEN** the system logs an error and returns a config load error, causing the reconcile loop to fail
+
+#### Scenario: ConfigMap exists with explicit zero preRunDelay
+- **WHEN** the `alerts-adapter-config` ConfigMap contains `preRunDelay: 0s`
+- **THEN** the system uses `preRunDelay=0s` (same as default, no delay)
+
+#### Scenario: ConfigMap exists with explicit zero postRunDelay
+- **WHEN** the `alerts-adapter-config` ConfigMap contains `postRunDelay: 0s`
+- **THEN** the system uses `postRunDelay=0s` (overrides the 1h default, no delay)
+
+#### Scenario: ConfigMap exists with negative preRunDelay or postRunDelay
+- **WHEN** the `alerts-adapter-config` ConfigMap contains a negative duration for `preRunDelay` or `postRunDelay`
+- **THEN** the system clamps the value to `0s` (no error logged)
+
+#### Scenario: ConfigMap exists with invalid YAML
+- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains content that is not valid YAML
+- **THEN** the system logs an error and returns a config load error, causing the reconcile loop to fail
+
+#### Scenario: ConfigMap exists without the config.yaml key
+- **WHEN** the `alerts-adapter-config` ConfigMap exists but does not contain a `config.yaml` key
+- **THEN** the system falls back to all default values
+
+## RENAMED Requirements
+
+### Requirement: ConfigMap key initialDelay
+- **FROM:** `initialDelay`
+- **TO:** `preRunDelay`
+
+### Requirement: ConfigMap key cooldownWindow
+- **FROM:** `cooldownWindow`
+- **TO:** `postRunDelay`
+
+## REMOVED Requirements
+
+### Requirement: Non-positive duration fallback to nonzero default
+**Reason**: Zero is now a valid value meaning "no delay". When a field is explicitly set to 0s or a negative value, it is clamped to 0s, overriding the default. When a field is absent, the default is used (`preRunDelay`: 0s, `postRunDelay`: 1h).
+**Migration**: No action needed. The `pollInterval` field retains its existing validation (must be positive, falls back to 30s default).

--- a/openspec/changes/archive/2026-07-21-rename-delay-config/specs/poll-loop/spec.md
+++ b/openspec/changes/archive/2026-07-21-rename-delay-config/specs/poll-loop/spec.md
@@ -1,7 +1,5 @@
-## Purpose
-Continuously poll AlertManager for firing alerts and create AgenticRun CRs for new alerts, with stateless deduplication to avoid duplicate or premature AgenticRuns.
+## MODIFIED Requirements
 
-## Requirements
 ### Requirement: Poll AlertManager on a fixed interval
 The system SHALL read operational parameters (`pollInterval`, `preRunDelay`, `postRunDelay`) from the `ConfigSource` at the start of each reconcile cycle and use them for that cycle's filtering and deduplication rules. The default poll interval is 30 seconds. When the loaded `pollInterval` differs from the current ticker interval, the system SHALL reset the ticker to the new interval. The filter order SHALL be: receiver allowlist -> severity -> pre-run delay -> active AgenticRun -> post-run delay.
 
@@ -40,17 +38,6 @@ The system SHALL not create an AgenticRun for an alert that has been firing for 
 - **WHEN** `preRunDelay` is greater than 0 and `now - alert.startsAt` is equal to or greater than `preRunDelay`
 - **THEN** the alert passes the pre-run delay check
 
-### Requirement: Skip alerts with active AgenticRuns
-The system SHALL not create an AgenticRun for an alert that already has an active (non-terminal) AgenticRun, identified by matching the alert fingerprint label.
-
-#### Scenario: Active AgenticRun exists for alert
-- **WHEN** an AgenticRun with matching fingerprint label exists and its phase is Pending, Analyzing, Proposed, Executing, Verifying, or Escalating
-- **THEN** the alert is skipped and logged at Debug level
-
-#### Scenario: No AgenticRun exists for alert
-- **WHEN** no AgenticRun with matching fingerprint label exists
-- **THEN** the alert passes the active-run check
-
 ### Requirement: Skip alerts within post-run delay
 The system SHALL not create an AgenticRun for an alert that has a terminal AgenticRun (Completed, Failed, Denied, Escalated) within the configured `postRunDelay` (default 1h), to avoid repeated analysis of an alert that has already been investigated. When `postRunDelay` is 0, this check is a no-op and all alerts pass.
 
@@ -65,14 +52,3 @@ The system SHALL not create an AgenticRun for an alert that has a terminal Agent
 #### Scenario: Terminal AgenticRun outside postRunDelay
 - **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in a terminal phase and its terminal condition's `LastTransitionTime` is equal to or greater than `postRunDelay` ago
 - **THEN** the alert passes the post-run delay check
-
-### Requirement: Shut down gracefully on OS signals
-The system SHALL exit cleanly when it receives SIGTERM or SIGINT, completing any in-flight poll cycle before stopping.
-
-#### Scenario: SIGTERM received while idle
-- **WHEN** the adapter receives SIGTERM between poll cycles
-- **THEN** the adapter exits with status code 0
-
-#### Scenario: SIGINT received during poll
-- **WHEN** the adapter receives SIGINT during a poll cycle
-- **THEN** the adapter completes or cancels the in-flight cycle and exits with status code 0

--- a/openspec/changes/archive/2026-07-21-rename-delay-config/tasks.md
+++ b/openspec/changes/archive/2026-07-21-rename-delay-config/tasks.md
@@ -1,0 +1,22 @@
+## 1. Config package
+
+- [x] 1.1 Rename constants: `DefaultInitialDelay` to `DefaultPreRunDelay` (value 0), `DefaultCooldownWindow` to `DefaultPostRunDelay` (value 1h)
+- [x] 1.2 Rename `Config` struct fields: `InitialDelay` to `PreRunDelay`, `CooldownWindow` to `PostRunDelay`
+- [x] 1.3 Rename `configFile` YAML tags: `initialDelay` to `preRunDelay`, `cooldownWindow` to `postRunDelay`
+- [x] 1.4 Update `LoadFromFile` validation: use `isSet` to distinguish "not set" (keep default) from "explicit 0" (override to 0); clamp negative values to 0 silently; return an error on unparseable duration syntax
+- [x] 1.5 Update config tests: rename references, update expected defaults to 0, test zero/negative clamping without error log, test that invalid syntax returns an error
+
+## 2. Adapter package
+
+- [x] 2.1 Rename field references: `cfg.InitialDelay` to `cfg.PreRunDelay`, `cfg.CooldownWindow` to `cfg.PostRunDelay`
+- [x] 2.2 Rename helper functions: `skipInitialDelay` to `tooEarly`, `inCooldown` to `tooRecent`
+- [x] 2.3 Add short-circuit: skip `tooEarly` check when `PreRunDelay` is 0, skip `tooRecent` check when `PostRunDelay` is 0
+- [x] 2.4 Update log messages to use new field names
+- [x] 2.5 Update adapter tests: rename references, update `defaultTestConfig()` defaults to 0, add test cases for 0-value short-circuits
+
+## 3. Docs and manifests
+
+- [x] 3.1 Update `manifests/configmap.yaml`: rename keys, comment them out, show `preRunDelay: 5m` and `postRunDelay: 1h` as examples
+- [x] 3.2 Update `README.md`: rename config table entries, update defaults, update example ConfigMap
+- [x] 3.3 Update `ARCHITECTURE.md`: rename references in flow pseudocode, requirements tables, and config reference
+- [x] 3.4 Update `AGENTS.md`: rename references in the architecture summary

--- a/openspec/specs/configmap-config/spec.md
+++ b/openspec/specs/configmap-config/spec.md
@@ -15,15 +15,23 @@ The system SHALL read the `alerts-adapter-config` ConfigMap from the adapter's n
 
 #### Scenario: ConfigMap exists with invalid duration value
 - **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains an unparseable duration string for one or more fields
-- **THEN** the system falls back to the default value for each invalid field and logs a warning for each invalid field
+- **THEN** the system logs an error and returns a config load error, causing the reconcile loop to fail
 
-#### Scenario: ConfigMap exists with non-positive duration value
-- **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains a zero or negative duration (e.g., `pollInterval: 0s` or `initialDelay: -1m`)
-- **THEN** the system falls back to the default value for each non-positive field and logs a warning for each non-positive field
+#### Scenario: ConfigMap exists with explicit zero preRunDelay
+- **WHEN** the `alerts-adapter-config` ConfigMap contains `preRunDelay: 0s`
+- **THEN** the system uses `preRunDelay=0s` (same as default, no delay)
+
+#### Scenario: ConfigMap exists with explicit zero postRunDelay
+- **WHEN** the `alerts-adapter-config` ConfigMap contains `postRunDelay: 0s`
+- **THEN** the system uses `postRunDelay=0s` (overrides the 1h default, no delay)
+
+#### Scenario: ConfigMap exists with negative preRunDelay or postRunDelay
+- **WHEN** the `alerts-adapter-config` ConfigMap contains a negative duration for `preRunDelay` or `postRunDelay`
+- **THEN** the system clamps the value to `0s` (no error logged)
 
 #### Scenario: ConfigMap exists with invalid YAML
 - **WHEN** the `alerts-adapter-config` ConfigMap exists and its `config.yaml` key contains content that is not valid YAML
-- **THEN** the system falls back to all default values and logs a warning
+- **THEN** the system logs an error and returns a config load error, causing the reconcile loop to fail
 
 #### Scenario: ConfigMap exists without the config.yaml key
 - **WHEN** the `alerts-adapter-config` ConfigMap exists but does not contain a `config.yaml` key
@@ -41,15 +49,15 @@ The system SHALL NOT fail or exit when the `alerts-adapter-config` ConfigMap doe
 - **THEN** the system reverts to default values on the next reconcile cycle and logs at Info level
 
 ### Requirement: Use well-defined default values
-The system SHALL use the following default values when no ConfigMap is present or when individual fields are missing or invalid:
+The system SHALL use the following default values when no ConfigMap is present or when individual fields are missing:
 - `pollInterval`: 30 seconds
-- `initialDelay`: 5 minutes
-- `cooldownWindow`: 1 hour
+- `preRunDelay`: 0 seconds
+- `postRunDelay`: 1 hour
 - `allowedReceivers`: empty list (no alerts are processed until explicitly configured)
 
 #### Scenario: All defaults applied
 - **WHEN** no ConfigMap exists
-- **THEN** the system uses `pollInterval=30s`, `initialDelay=5m`, `cooldownWindow=1h`, `allowedReceivers=[]`
+- **THEN** the system uses `pollInterval=30s`, `preRunDelay=0s`, `postRunDelay=1h`, `allowedReceivers=[]`
 
 ### Requirement: Resolve the adapter namespace from the environment
 The system SHALL read the `POD_NAMESPACE` environment variable to determine the namespace for the ConfigMap. If the variable is not set, it SHALL fall back to `openshift-lightspeed`.


### PR DESCRIPTION
Rename config keys and Go identifiers to clarify their relationship to the AgenticRun lifecycle. Change defaults from 5m/1h to 0s so the adapter creates AgenticRuns immediately unless delays are explicitly configured.

Breaking changes:
- ConfigMap keys renamed (initialDelay -> preRunDelay, cooldownWindow -> postRunDelay)
- LoadFromFile now returns (Config, error); invalid YAML or unparseable durations cause an error instead of silent fallback
- Zero/negative values clamp to 0s silently (no error log)


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable pre-run and post-run alert deduplication delays.
  - Zero delays now disable the corresponding filtering; negative values are clamped to zero.
  - Invalid YAML or duration settings now prevent startup with a clear configuration error.

- **Documentation**
  - Updated configuration examples and guidance to reflect the new settings and defaults.
  - Clarified ConfigMap reload and error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->