### PR TITLE
feat: include skill paths in AgenticRun request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ coverage:
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 container-build:
-	podman build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Containerfile .
+	podman build --no-cache -t $(IMAGE_NAME):$(IMAGE_TAG) -f Containerfile .
 
 container-push: container-build
 	podman push $(IMAGE_NAME):$(IMAGE_TAG)

--- a/internal/agenticrun/build.go
+++ b/internal/agenticrun/build.go
@@ -46,7 +46,7 @@ var (
 
 	//go:embed request.tmpl
 	requestTemplateStr string
-	requestTemplate    = template.Must(template.New("request").Parse(requestTemplateStr))
+	requestTemplate = template.Must(template.New("request").Parse(requestTemplateStr))
 )
 
 type requestData struct {
@@ -57,6 +57,7 @@ type requestData struct {
 	Summary     string
 	Description string
 	Labels      map[string]string
+	SkillPaths  []string
 }
 
 // Build constructs an AgenticRun from a single Alertmanager GettableAlert.
@@ -80,7 +81,7 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 	}
 	startsAt := time.Time(*a.StartsAt)
 
-	request, err := buildRequest(a)
+	request, err := buildRequest(a, tools.Shared)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +197,14 @@ func buildAnnotations(a *models.GettableAlert) map[string]string {
 }
 
 // buildRequest renders the embedded template with alert data for the analysis agent.
-func buildRequest(a *models.GettableAlert) (string, error) {
+func buildRequest(a *models.GettableAlert, sharedSkills []agenticv1alpha1.SkillsSource) (string, error) {
+	var skillPaths []string
+	for _, s := range sharedSkills {
+		for _, p := range s.Paths {
+			skillPaths = append(skillPaths, "/app"+p)
+		}
+	}
+
 	data := requestData{
 		AlertName:   a.Labels["alertname"],
 		Severity:    a.Labels["severity"],
@@ -205,6 +213,7 @@ func buildRequest(a *models.GettableAlert) (string, error) {
 		Summary:     a.Annotations["summary"],
 		Description: a.Annotations["description"],
 		Labels:      a.Labels,
+		SkillPaths:  skillPaths,
 	}
 
 	var buf bytes.Buffer

--- a/internal/agenticrun/build_test.go
+++ b/internal/agenticrun/build_test.go
@@ -297,7 +297,7 @@ func TestBuildRequestWithSkillPaths(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if strings.Contains(p.Spec.Request, "Investigate using the skill at") {
-			t.Error("request should not contain skill path when no shared skills set")
+			t.Error("request should not contain skill paths when no shared skills set")
 		}
 	})
 

--- a/internal/agenticrun/build_test.go
+++ b/internal/agenticrun/build_test.go
@@ -281,12 +281,71 @@ func TestBuildRequest(t *testing.T) {
 		"Namespace: production",
 		"Runbook URL: https://runbooks.example.com/KubePodCrashLooping",
 		"Description: Pod my-pod has restarted 5 times in the last hour",
-		"alertname: KubePodCrashLooping",
 	} {
 		if !strings.Contains(p.Spec.Request, want) {
 			t.Errorf("request does not contain %q\nfull request:\n%s", want, p.Spec.Request)
 		}
 	}
+}
+
+func TestBuildRequestWithSkillPaths(t *testing.T) {
+	a := makeAlert("KubePodCrashLooping", "production", "abcdef12", "critical")
+
+	t.Run("no shared skills omits skill paths", func(t *testing.T) {
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(p.Spec.Request, "Investigate using the skill at") {
+			t.Error("request should not contain skill path when no shared skills set")
+		}
+	})
+
+	t.Run("shared skills lists all paths with /app prefix", func(t *testing.T) {
+		tc := config.ToolsConfig{
+			Shared: []agenticv1alpha1.SkillsSource{
+				{Image: "registry.example.com/skills:latest", Paths: []string{
+					"/skills/cluster-troubleshoot/investigate-alert",
+					"/skills/prometheus",
+				}},
+			},
+		}
+		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, want := range []string{
+			"Investigate using the skill at",
+			"/app/skills/cluster-troubleshoot/investigate-alert",
+			"/app/skills/prometheus",
+		} {
+			if !strings.Contains(p.Spec.Request, want) {
+				t.Errorf("request does not contain %q\nfull request:\n%s", want, p.Spec.Request)
+			}
+		}
+	})
+
+	t.Run("multiple shared skill sources lists all paths", func(t *testing.T) {
+		tc := config.ToolsConfig{
+			Shared: []agenticv1alpha1.SkillsSource{
+				{Image: "registry.example.com/skills-a:latest", Paths: []string{"/skills/alpha"}},
+				{Image: "registry.example.com/skills-b:latest", Paths: []string{"/skills/beta"}},
+			},
+		}
+		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, want := range []string{
+			"Investigate using the skill at",
+			"/app/skills/alpha",
+			"/app/skills/beta",
+		} {
+			if !strings.Contains(p.Spec.Request, want) {
+				t.Errorf("request does not contain %q\nfull request:\n%s", want, p.Spec.Request)
+			}
+		}
+	})
 }
 
 func TestBuildRequestWithoutRunbook(t *testing.T) {

--- a/internal/agenticrun/request.tmpl
+++ b/internal/agenticrun/request.tmpl
@@ -1,11 +1,10 @@
 Alert: {{ .AlertName }} ({{ .Severity }})
 Namespace: {{ .Namespace }}
 Description: {{ .Description }}
-Labels:
-{{ range $k, $v := .Labels }}  {{ $k }}: {{ $v }}
-{{ end -}}
 {{- if .RunbookURL }}
 Runbook URL: {{ .RunbookURL }}
 {{- end }}
 
-Investigate, follow causality chains to the root cause.
+{{- if .SkillPaths }}
+Investigate using the skill at{{ range .SkillPaths }} {{ . }}{{ end }}
+{{- end }}

--- a/internal/agenticrun/request.tmpl
+++ b/internal/agenticrun/request.tmpl
@@ -7,4 +7,6 @@ Runbook URL: {{ .RunbookURL }}
 
 {{- if .SkillPaths }}
 Investigate using the skill at{{ range .SkillPaths }} {{ . }}{{ end }}
+{{- else }}
+Investigate, follow causality chains to the root cause.
 {{- end }}

--- a/manifests/configmap.yaml
+++ b/manifests/configmap.yaml
@@ -23,33 +23,28 @@ data:
 
     # filtering: controls which alerts the adapter processes.
     filtering:
-      # allowedReceivers: only process alerts routed to these receivers (case-insensitive).
-      # No AgenticRuns are created until receivers are explicitly configured.
-      allowedReceivers:
-        - critical
+      # allowedReceivers: only process alerts that Alertmanager has routed to
+      # one of these receivers (as configured in Alertmanager's routing rules).
+      # In the OCP console, navigate to /settings/cluster/alertmanageryaml to
+      # view and edit Alertmanager routing rules and receivers.
+      #
+      # UNCOMMENT AND CONFIGURE at least one receiver to start automatic analysis.
+      #
+      # allowedReceivers:
+      #   - critical
 
     # deduplication: controls how the adapter identifies "the same problem" across
     # alert re-fires (e.g. pod restarts producing a new pod name).
-    # deduplication:
-    #   # ignoredLabels: labels stripped before computing the stable fingerprint.
-    #   # When set, fully replaces the defaults (no merging).
-    #   # When absent, defaults to: [pod, instance, endpoint, uid]
-    #   # Set to [] to include all labels in the fingerprint.
-    #   ignoredLabels:
-    #     - pod
-    #     - instance
-    #     - endpoint
-    #     - uid
-
-    # tools: shared skills for all workflow steps (maps to spec.tools on the AgenticRun).
-    # When configured, every AgenticRun created by the adapter includes these skills.
-    # Omit to create AgenticRuns with no tools.
-    # tools:
-    #   skills:
-    #     - image: registry.redhat.io/openshift-lightspeed/agentic-skills:latest
-    #       paths:
-    #         - /skills/prometheus
-    #         - /skills/cluster-diagnostics
+    deduplication:
+      # ignoredLabels: labels stripped before computing the stable fingerprint.
+      # When set, fully replaces the defaults (no merging).
+      # When absent, defaults to: [pod, instance, endpoint, uid]
+      # Set to [] to include all labels in the fingerprint.
+      ignoredLabels:
+        - pod
+        - instance
+        - endpoint
+        - uid
 
     # agent: override which agent handles AgenticRun workflow steps.
     # 'default' sets the agent for all steps; per-step keys override it.
@@ -60,23 +55,11 @@ data:
     #   execution: "execution-agent"
     #   verification: "verification-agent"
 
-    # Per-step tool overrides. When set, these replace the shared tools for that
-    # step on the AgenticRun (maps to spec.{analysis,execution,verification}.tools).
-    # analysis:
-    #   tools:
-    #     skills:
-    #       - image: registry.redhat.io/openshift-lightspeed/analysis-skills:latest
-    #         paths:
-    #           - /skills/diagnostic
-    # execution:
-    #   tools:
-    #     skills:
-    #       - image: registry.redhat.io/openshift-lightspeed/exec-skills:latest
-    #         paths:
-    #           - /skills/remediation
-    # verification:
-    #   tools:
-    #     skills:
-    #       - image: registry.redhat.io/openshift-lightspeed/verify-skills:latest
-    #         paths:
-    #           - /skills/validation
+    # tools: shared skills for all workflow steps (maps to spec.tools on the AgenticRun).
+    # When configured, every AgenticRun created by the adapter includes these skills.
+    # Omit to create AgenticRuns with no tools.
+    tools:
+      skills:
+        - image: quay.io/openshiftanalytics/agentic-skills:latest
+          paths:
+            - /skills/cluster-troubleshoot/investigate-alert

--- a/openspec/changes/add-skill-paths-to-request/.openspec.yaml
+++ b/openspec/changes/add-skill-paths-to-request/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/add-skill-paths-to-request/design.md
+++ b/openspec/changes/add-skill-paths-to-request/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The alerts adapter builds an AgenticRun CR for each firing alert. The `spec.request` field is a natural-language prompt rendered from `request.tmpl` that tells the analysis agent what to investigate. Skills (OCI images with tooling) are already mounted into the agent container via `spec.tools.skills`, but the agent has no way to know the filesystem paths where those skills are available.
+
+Skills are mounted under `/app` in the agent container, so a skill with path `/skills/prometheus` in the OCI image is available at `/app/skills/prometheus` at runtime.
+
+This approach is a workaround: the host (Agentic Lightspeed) does not currently load skills automatically from mounted volumes. Until the operator supports automatic skill discovery, the adapter must embed skill paths in the request text so the agent knows where to look.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Include shared skill paths in the request text so the agent can discover and use them.
+- Prepend `/app` to each skill path to reflect the actual mount location in the agent container.
+- Remove the raw Labels block from the template (alert identity is already conveyed by the structured fields).
+
+**Non-Goals:**
+
+- Per-step skill paths in the request. The request is consumed by the analysis agent; per-step skills are handled by the operator.
+- Validation of skill paths beyond what `config.LoadFromFile` already does.
+
+## Decisions
+
+**Skill paths are collected from all shared skill sources and flattened into a single list.**
+Each `SkillsSource` can have multiple paths and there can be multiple sources. All paths are collected, each prefixed with `/app`, and passed to the template as a flat `[]string`. This keeps the template simple.
+
+**Paths are rendered on a single line, space-separated.**
+A single "Investigate using the skill at" line followed by all paths. This is concise and sufficient for the agent to parse.
+
+**The `/app` prefix is applied at render time, not stored in config.**
+The config stores OCI-image-relative paths (e.g., `/skills/prometheus`). The `/app` prefix is an agent container concern and is applied when building the request.
+
+## Risks / Trade-offs
+
+**Mount prefix is hardcoded.** If the operator changes the mount point from `/app`, the request will contain wrong paths. This is acceptable because the mount point is an operator convention unlikely to change, and the request is advisory text for the agent, not a hard contract.
+
+**This is a workaround.** Once Agentic Lightspeed supports automatic skill loading, this hint in the request text should be removed and the skill paths section of the template deleted.

--- a/openspec/changes/add-skill-paths-to-request/proposal.md
+++ b/openspec/changes/add-skill-paths-to-request/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The AgenticRun request text tells the analysis agent what to investigate, but it does not tell the agent where to find the skills mounted from OCI images. Without explicit paths in the request, the agent has no way to discover and use the configured skills for investigation.
+
+This is a workaround because the host (Agentic Lightspeed) does not currently load skills automatically. Until the operator supports automatic skill discovery, embedding the paths in the request text is the only way for the agent to locate them.
+
+## What Changes
+
+- The request template includes skill paths (prefixed with `/app`) from shared skills configuration when present.
+- The request template no longer outputs raw alert labels (the Labels block has been removed as redundant with the structured fields already present).
+- `buildRequest` accepts the shared skills configuration and extracts all paths, prepending `/app` to each.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `agenticrun-building`: The request template now conditionally includes shared skill paths so the agent knows where to find mounted skills at runtime. The Labels block is removed from the template.
+
+## Impact
+
+- `internal/agenticrun/build.go`: `requestData` struct gains `SkillPaths` field; `buildRequest` signature changes to accept shared skills.
+- `internal/agenticrun/request.tmpl`: Template updated to list skill paths and remove Labels block.
+- `internal/agenticrun/build_test.go`: New test for skill paths in request; existing test updated to remove labels assertion.

--- a/openspec/changes/add-skill-paths-to-request/specs/agenticrun-building/spec.md
+++ b/openspec/changes/add-skill-paths-to-request/specs/agenticrun-building/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Render a structured request from alert data
+The system SHALL render the `spec.request` field using an embedded Go template that includes the alert name, severity, namespace, description, and runbook URL. When shared skills are configured, the request SHALL include all skill paths prefixed with `/app` so the agent can locate mounted skills at runtime.
+
+#### Scenario: Alert with all annotation fields populated
+- **WHEN** the alert has summary and description annotations
+- **THEN** both are included in the rendered request
+
+#### Scenario: Alert with missing annotations
+- **WHEN** the alert has no summary or description annotations
+- **THEN** the corresponding fields are empty in the rendered request and no error is returned
+
+#### Scenario: Shared skills configured with one source and multiple paths
+- **WHEN** an AgenticRun is built with shared skills containing one source with paths `/skills/cluster-troubleshoot/investigate-alert` and `/skills/prometheus`
+- **THEN** the request SHALL contain "Investigate using the skill at" followed by `/app/skills/cluster-troubleshoot/investigate-alert` and `/app/skills/prometheus`
+
+#### Scenario: Shared skills configured with multiple sources
+- **WHEN** an AgenticRun is built with shared skills containing multiple sources, each with their own paths
+- **THEN** the request SHALL contain "Investigate using the skill at" followed by all paths from all sources, each prefixed with `/app`
+
+#### Scenario: No shared skills configured
+- **WHEN** an AgenticRun is built with no shared skills
+- **THEN** the request SHALL NOT contain "Investigate using the skill at"

--- a/openspec/changes/add-skill-paths-to-request/specs/agenticrun-building/spec.md
+++ b/openspec/changes/add-skill-paths-to-request/specs/agenticrun-building/spec.md
@@ -1,15 +1,15 @@
 ## MODIFIED Requirements
 
 ### Requirement: Render a structured request from alert data
-The system SHALL render the `spec.request` field using an embedded Go template that includes the alert name, severity, namespace, description, and runbook URL. When shared skills are configured, the request SHALL include all skill paths prefixed with `/app` so the agent can locate mounted skills at runtime.
+The system SHALL render the `spec.request` field using an embedded Go template that includes the alert name, severity, namespace, description, runbook URL, and generic investigation guidance. When shared skills are configured, the request SHALL additionally include all skill paths prefixed with `/app` so the agent can locate mounted skills at runtime.
 
-#### Scenario: Alert with all annotation fields populated
-- **WHEN** the alert has summary and description annotations
-- **THEN** both are included in the rendered request
+#### Scenario: Alert with description annotation populated
+- **WHEN** the alert has a description annotation
+- **THEN** the description is included in the rendered request
 
-#### Scenario: Alert with missing annotations
-- **WHEN** the alert has no summary or description annotations
-- **THEN** the corresponding fields are empty in the rendered request and no error is returned
+#### Scenario: Alert with missing description annotation
+- **WHEN** the alert has no description annotation
+- **THEN** the description field is empty in the rendered request and no error is returned
 
 #### Scenario: Shared skills configured with one source and multiple paths
 - **WHEN** an AgenticRun is built with shared skills containing one source with paths `/skills/cluster-troubleshoot/investigate-alert` and `/skills/prometheus`

--- a/openspec/changes/add-skill-paths-to-request/tasks.md
+++ b/openspec/changes/add-skill-paths-to-request/tasks.md
@@ -1,0 +1,11 @@
+## 1. Template and request builder
+
+- [ ] 1.1 Add `SkillPaths []string` field to `requestData` struct in `build.go`
+- [ ] 1.2 Update `buildRequest` to accept shared skills, collect all paths with `/app` prefix, and populate `SkillPaths`
+- [ ] 1.3 Update `request.tmpl` to conditionally render skill paths on a single space-separated line
+- [ ] 1.4 Remove the Labels block from `request.tmpl`
+
+## 2. Tests
+
+- [ ] 2.1 Add `TestBuildRequestWithSkillPaths` covering: no shared skills, single source with multiple paths, multiple sources
+- [ ] 2.2 Update `TestBuildRequest` to remove the labels assertion


### PR DESCRIPTION
Embed shared skill paths (prefixed with /app) in the request template so the analysis agent can discover mounted skills at runtime. Remove the raw Labels block from the template as redundant. Update the default ConfigMap to uncomment deduplication and tools configuration. Add --no-cache to container-build to avoid stale image layers.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analysis requests now include configured shared skill paths, helping agents locate and use available skills.
  * Runbook URLs are included in investigation instructions when configured.
  * Default configuration now supports shared tools and receiver filtering.

* **Bug Fixes**
  * Container builds now run without using cached layers.

* **Documentation**
  * Added design, proposal, specification, and task documentation for skill-path support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->