### PR TITLE
konflux: add labels to the last pushed image: main, latest

### DIFF
--- a/.tekton/lightspeed-agentic-alerts-adapter-push.yaml
+++ b/.tekton/lightspeed-agentic-alerts-adapter-push.yaml
@@ -492,6 +492,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - main
+        - latest
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Built images are now automatically tagged with both `main` and `latest` for easier identification and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->