### PR TITLE
OBSINTA-1573: store both original and dedup fingerprints on AgenticRun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Three internal packages, each behind an interface, wired together in `cmd/alerts
 
 - **`internal/alertmanager`** — AlertManager API client. Reads bearer token on every call (handles rotation). TLS via in-cluster CA. Implements `adapter.AlertSource`.
 - **`internal/agenticrun`** — Two concerns: `build.go` translates an alert into an `AgenticRun` CR (deterministic name from alertname, namespace, and startsAt hash; embedded Go template `request.tmpl` for the request field); `client.go` wraps controller-runtime to create/list AgenticRuns. Implements `adapter.AgenticRunClient`.
-- **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `preRunDelay` (default 0s), with an active (non-terminal) AgenticRun, or within `postRunDelay` (default 1h) of a terminal AgenticRun. Matching is by `alert-fingerprint` label (stable FNV-64a hash of labels minus configurable ignored labels).
+- **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `preRunDelay` (default 0s), with an active (non-terminal) AgenticRun, or within `postRunDelay` (default 1h) of a terminal AgenticRun. Matching is by `alert-dedup-fingerprint` label (stable FNV-64a hash of labels minus configurable ignored labels).
 
 The AgenticRun CRD types come from `github.com/openshift/lightspeed-agentic-operator/api`.
 
@@ -36,7 +36,7 @@ The AgenticRun CRD types come from `github.com/openshift/lightspeed-agentic-oper
 - Polls (not webhooks) for resilience — restart immediately sees all firing alerts.
 - AgenticRuns always created in `openshift-lightspeed` namespace.
 - 409 AlreadyExists on create is expected and handled as a no-op (returns `false, nil`).
-- Stable fingerprint (FNV-64a[:8] of sorted labels minus configurable ignored labels) is used for dedup matching via the `alert-fingerprint` label. Default ignored labels: `pod`, `instance`, `endpoint`, `uid`. Configurable via `deduplication.ignoredLabels` in the ConfigMap. AgenticRun names use a hash of the alert's `startsAt` timestamp for uniqueness.
+- Two fingerprints on each AgenticRun CR: `alert-fingerprint` stores the original AlertManager fingerprint (for UI lookups by alert), `alert-dedup-fingerprint` stores the stable fingerprint (FNV-64a[:8] of sorted labels minus configurable ignored labels, used for dedup matching). Default ignored labels: `pod`, `instance`, `endpoint`, `uid`. Configurable via `deduplication.ignoredLabels` in the ConfigMap. AgenticRun names use a hash of the alert's `startsAt` timestamp for uniqueness.
 - Terminal phases: Completed, Failed, Denied, Escalated.
 - `preRunDelay` (default 0s) and `postRunDelay` (default 1h) are clamped to 0 for zero or negative values. Both can be explicitly set to `0s` to disable the delay. Invalid duration syntax causes a config load error.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,7 +127,7 @@ Examples:
 
 Components are sanitized to conform to DNS subdomain rules (RFC 1123): lowercased, non-alphanumeric characters replaced, truncated to fit the 63-character limit.
 
-Deduplication uses the `alert-fingerprint` label (first 8 chars of AlertManager's fingerprint, a hash of the alert's label set) to match alerts to existing AgenticRuns. The fingerprint is not part of the AgenticRun name — it is only stored as a label for matching.
+Deduplication uses the `alert-dedup-fingerprint` label (stable FNV-64a hash of labels minus configurable ignored labels, truncated to 8 hex characters) to match alerts to existing AgenticRuns. The original AlertManager fingerprint is stored separately in the `alert-fingerprint` label for UI lookups. Neither fingerprint is part of the AgenticRun name — they are only stored as labels for matching.
 
 ### Alert to AgenticRun Mapping
 
@@ -204,7 +204,8 @@ spec:
 metadata:
   labels:
     agentic.openshift.io/source: alertmanager
-    agentic.openshift.io/alert-fingerprint: <fingerprint[:8]>
+    agentic.openshift.io/alert-fingerprint: <AlertManager fingerprint[:8]>
+    agentic.openshift.io/alert-dedup-fingerprint: <stable fingerprint[:8]>
     agentic.openshift.io/alert-name: <alertname, lowercased>
     agentic.openshift.io/alert-severity: <severity>
   annotations:

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -232,7 +232,7 @@ func tooEarly(alert *models.GettableAlert, now time.Time, threshold time.Duratio
 
 func hasActiveRun(stableFingerprint string, runs []agenticv1alpha1.AgenticRun) bool {
 	for i := range runs {
-		if runs[i].Labels["agentic.openshift.io/alert-fingerprint"] != stableFingerprint {
+		if runs[i].Labels[agenticrun.LabelDedupFingerprint] != stableFingerprint {
 			continue
 		}
 		phase := agenticv1alpha1.DerivePhase(runs[i].Status.Conditions)
@@ -245,7 +245,7 @@ func hasActiveRun(stableFingerprint string, runs []agenticv1alpha1.AgenticRun) b
 
 func tooRecent(stableFingerprint string, runs []agenticv1alpha1.AgenticRun, now time.Time, window time.Duration) bool {
 	for i := range runs {
-		if runs[i].Labels["agentic.openshift.io/alert-fingerprint"] != stableFingerprint {
+		if runs[i].Labels[agenticrun.LabelDedupFingerprint] != stableFingerprint {
 			continue
 		}
 		tt := terminalTime(&runs[i])

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -98,8 +98,8 @@ func makeRun(fingerprint string, conditions []metav1.Condition) agenticv1alpha1.
 			Name:      "test-" + fingerprint,
 			Namespace: "openshift-lightspeed",
 			Labels: map[string]string{
-				"agentic.openshift.io/alert-fingerprint": fingerprint,
-				"agentic.openshift.io/source":            "alertmanager",
+				agenticrun.LabelDedupFingerprint: fingerprint,
+				agenticrun.LabelSource:                          "alertmanager",
 			},
 		},
 		Status: agenticv1alpha1.AgenticRunStatus{

--- a/internal/agenticrun/build.go
+++ b/internal/agenticrun/build.go
@@ -26,12 +26,13 @@ const (
 	runNamespace = "openshift-lightspeed"
 	defaultAgent = "default"
 
-	labelSource      = "agentic.openshift.io/source"
-	labelFingerprint = "agentic.openshift.io/alert-fingerprint"
-	labelAlertName   = "agentic.openshift.io/alert-name"
-	labelSeverity    = "agentic.openshift.io/alert-severity"
-	annotStartsAt    = "agentic.openshift.io/alert-starts-at"
-	annotSummary     = "agentic.openshift.io/alert-summary"
+	LabelSource           = "agentic.openshift.io/source"
+	LabelFingerprint      = "agentic.openshift.io/alert-fingerprint"
+	LabelDedupFingerprint = "agentic.openshift.io/alert-dedup-fingerprint"
+	LabelAlertName        = "agentic.openshift.io/alert-name"
+	LabelSeverity         = "agentic.openshift.io/alert-severity"
+	AnnotStartsAt         = "agentic.openshift.io/alert-starts-at"
+	AnnotSummary          = "agentic.openshift.io/alert-summary"
 
 	sourceValue = "alertmanager"
 
@@ -72,6 +73,7 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 
 	alertName := a.Labels["alertname"]
 	namespace := a.Labels["namespace"]
+	originalFP := *a.Fingerprint
 	stableFP := StableFingerprint(a.Labels, ignoredLabels)
 	severity := a.Labels["severity"]
 
@@ -107,7 +109,7 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        buildName(alertName, namespace, startsAt),
 			Namespace:   runNamespace,
-			Labels:      buildLabels(alertName, severity, stableFP),
+			Labels:      buildLabels(alertName, severity, originalFP, stableFP),
 			Annotations: buildAnnotations(a),
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{
@@ -168,12 +170,13 @@ func startsAtHash(t time.Time) string {
 }
 
 // buildLabels sets Kubernetes labels for alert traceability and filtering.
-func buildLabels(alertName, severity, stableFingerprint string) map[string]string {
+func buildLabels(alertName, severity, originalFingerprint, stableFingerprint string) map[string]string {
 	return map[string]string{
-		labelSource:      sourceValue,
-		labelFingerprint: stableFingerprint,
-		labelAlertName:   sanitizeLabelValue(strings.ToLower(alertName)),
-		labelSeverity:    sanitizeLabelValue(severity),
+		LabelSource:            sourceValue,
+		LabelFingerprint:       sanitizeLabelValue(originalFingerprint[:min(len(originalFingerprint), fingerprintLen)]),
+		LabelDedupFingerprint: stableFingerprint,
+		LabelAlertName:         sanitizeLabelValue(strings.ToLower(alertName)),
+		LabelSeverity:          sanitizeLabelValue(severity),
 	}
 }
 
@@ -182,14 +185,14 @@ func buildAnnotations(a *models.GettableAlert) map[string]string {
 	annots := map[string]string{}
 
 	if a.StartsAt != nil && !time.Time(*a.StartsAt).IsZero() {
-		annots[annotStartsAt] = time.Time(*a.StartsAt).UTC().Format(time.RFC3339)
+		annots[AnnotStartsAt] = time.Time(*a.StartsAt).UTC().Format(time.RFC3339)
 	}
 
 	if summary, ok := a.Annotations["summary"]; ok && summary != "" {
 		if len(summary) > maxSummaryLen {
 			summary = summary[:maxSummaryLen]
 		}
-		annots[annotSummary] = summary
+		annots[AnnotSummary] = summary
 	}
 
 	return annots

--- a/internal/agenticrun/build_test.go
+++ b/internal/agenticrun/build_test.go
@@ -57,14 +57,15 @@ func TestBuild(t *testing.T) {
 			expectedNamespace: runNamespace,
 			expectedTargetNS:  []string{"production"},
 			expectedLabels: map[string]string{
-				labelSource: sourceValue,
-				labelFingerprint: StableFingerprint(map[string]string{
+				LabelSource:      sourceValue,
+				LabelFingerprint: "abcdef12",
+				LabelDedupFingerprint: StableFingerprint(map[string]string{
 					"alertname": "KubePodCrashLooping",
 					"namespace": "production",
 					"severity":  "critical",
 				}, noIgnored),
-				labelAlertName: "kubepodcrashlooping",
-				labelSeverity:  "critical",
+				LabelAlertName: "kubepodcrashlooping",
+				LabelSeverity:  "critical",
 			},
 		},
 		{
@@ -79,31 +80,33 @@ func TestBuild(t *testing.T) {
 			expectedNamespace: runNamespace,
 			expectedTargetNS:  nil,
 			expectedLabels: map[string]string{
-				labelSource: sourceValue,
-				labelFingerprint: StableFingerprint(map[string]string{
+				LabelSource:      sourceValue,
+				LabelFingerprint: "ff00ff00",
+				LabelDedupFingerprint: StableFingerprint(map[string]string{
 					"alertname": "ClusterVersionAvailable",
 					"severity":  "info",
 				}, noIgnored),
-				labelAlertName: "clusterversionavailable",
-				labelSeverity:  "info",
+				LabelAlertName: "clusterversionavailable",
+				LabelSeverity:  "info",
 			},
 		},
 		{
-			name:              "ignored labels stripped from fingerprint",
+			name:              "ignored labels stripped from stable fingerprint",
 			alert:             makeAlert("TestAlert", "ns", "abc", "warning"),
 			ignoredLabels:     []string{"pod", "instance"},
 			expectedName:      "testalert-ns-895c8977",
 			expectedNamespace: runNamespace,
 			expectedTargetNS:  []string{"ns"},
 			expectedLabels: map[string]string{
-				labelSource: sourceValue,
-				labelFingerprint: StableFingerprint(map[string]string{
+				LabelSource:      sourceValue,
+				LabelFingerprint: "abc",
+				LabelDedupFingerprint: StableFingerprint(map[string]string{
 					"alertname": "TestAlert",
 					"namespace": "ns",
 					"severity":  "warning",
 				}, []string{"pod", "instance"}),
-				labelAlertName: "testalert",
-				labelSeverity:  "warning",
+				LabelAlertName: "testalert",
+				LabelSeverity:  "warning",
 			},
 		},
 	}
@@ -217,7 +220,7 @@ func TestBuildAnnotations(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		got := p.Annotations[annotStartsAt]
+		got := p.Annotations[AnnotStartsAt]
 		expected := "2026-01-15T10:30:00Z"
 		if got != expected {
 			t.Errorf("starts-at = %q, want %q", got, expected)
@@ -230,7 +233,7 @@ func TestBuildAnnotations(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got := p.Annotations[annotSummary]; got != "Pod is crash looping" {
+		if got := p.Annotations[AnnotSummary]; got != "Pod is crash looping" {
 			t.Errorf("summary = %q, want %q", got, "Pod is crash looping")
 		}
 	})
@@ -245,10 +248,10 @@ func TestBuildAnnotations(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if _, ok := p.Annotations[annotStartsAt]; ok {
+		if _, ok := p.Annotations[AnnotStartsAt]; ok {
 			t.Error("expected no starts-at annotation for zero time")
 		}
-		if _, ok := p.Annotations[annotSummary]; ok {
+		if _, ok := p.Annotations[AnnotSummary]; ok {
 			t.Error("expected no summary annotation when empty")
 		}
 	})
@@ -261,7 +264,7 @@ func TestBuildAnnotations(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got := len(p.Annotations[annotSummary]); got != maxSummaryLen {
+		if got := len(p.Annotations[AnnotSummary]); got != maxSummaryLen {
 			t.Errorf("summary length = %d, want %d", got, maxSummaryLen)
 		}
 	})

--- a/internal/agenticrun/client.go
+++ b/internal/agenticrun/client.go
@@ -25,7 +25,7 @@ func NewClient(c client.Client, logger *slog.Logger) *Client {
 // source=alertmanager label.
 func (c *Client) ListAgenticRuns(ctx context.Context) ([]agenticv1alpha1.AgenticRun, error) {
 	var list agenticv1alpha1.AgenticRunList
-	if err := c.List(ctx, &list, client.MatchingLabels{labelSource: sourceValue}); err != nil {
+	if err := c.List(ctx, &list, client.MatchingLabels{LabelSource: sourceValue}); err != nil {
 		return nil, fmt.Errorf("agenticrun: listing runs: %w", err)
 	}
 	return list.Items, nil

--- a/internal/agenticrun/client_test.go
+++ b/internal/agenticrun/client_test.go
@@ -101,7 +101,7 @@ func TestListAgenticRuns(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "matching-abcdef12",
 			Namespace: runNamespace,
-			Labels:    map[string]string{labelSource: sourceValue},
+			Labels:    map[string]string{LabelSource: sourceValue},
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{
 			Request:  "matching",
@@ -112,7 +112,7 @@ func TestListAgenticRuns(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "unrelated-12345678",
 			Namespace: runNamespace,
-			Labels:    map[string]string{labelSource: "other"},
+			Labels:    map[string]string{LabelSource: "other"},
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{
 			Request:  "unrelated",

--- a/openspec/specs/agenticrun-building/spec.md
+++ b/openspec/specs/agenticrun-building/spec.md
@@ -3,15 +3,15 @@ Translate Alertmanager alerts into AgenticRun custom resources so the agentic op
 
 ## Requirements
 ### Requirement: Build an AgenticRun CR from a single alert
-The system SHALL convert an Alertmanager `GettableAlert` into an `AgenticRun` custom resource with deterministic naming, Kubernetes-safe metadata, and a templated request for the analysis agent. The `agentic.openshift.io/alert-fingerprint` label SHALL use the stable fingerprint computed from the alert's labels minus ignored labels, instead of AlertManager's fingerprint.
+The system SHALL convert an Alertmanager `GettableAlert` into an `AgenticRun` custom resource with deterministic naming, Kubernetes-safe metadata, and a templated request for the analysis agent. Two fingerprint labels SHALL be set: `agentic.openshift.io/alert-fingerprint` with the original AlertManager fingerprint (truncated to 8 characters) for UI lookups, and `agentic.openshift.io/alert-dedup-fingerprint` with the stable fingerprint computed from the alert's labels minus ignored labels for deduplication.
 
 #### Scenario: Alert with namespace label
 - **WHEN** the alert has a `namespace` label
-- **THEN** the AgenticRun name is `{alertname}-{namespace}-{startsAt_hash}`, `spec.targetNamespaces` is set to `[namespace]`, the `agentic.openshift.io/alert-fingerprint` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
+- **THEN** the AgenticRun name is `{alertname}-{namespace}-{startsAt_hash}`, `spec.targetNamespaces` is set to `[namespace]`, the `agentic.openshift.io/alert-fingerprint` label is set to the original AlertManager fingerprint (truncated to 8 characters), the `agentic.openshift.io/alert-dedup-fingerprint` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
 
 #### Scenario: Cluster-scoped alert (no namespace)
 - **WHEN** the alert has no `namespace` label
-- **THEN** the AgenticRun name is `{alertname}-{startsAt_hash}`, `spec.targetNamespaces` is omitted, the `agentic.openshift.io/alert-fingerprint` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
+- **THEN** the AgenticRun name is `{alertname}-{startsAt_hash}`, `spec.targetNamespaces` is omitted, the `agentic.openshift.io/alert-fingerprint` label is set to the original AlertManager fingerprint (truncated to 8 characters), the `agentic.openshift.io/alert-dedup-fingerprint` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
 
 #### Scenario: Deterministic naming produces idempotent creates
 - **WHEN** the same alert is passed to Build twice
@@ -19,7 +19,7 @@ The system SHALL convert an Alertmanager `GettableAlert` into an `AgenticRun` cu
 
 #### Scenario: Second alert for the same problem is deduplicated
 - **WHEN** two alerts differ only in ignored labels (e.g., different pod names) and an active AgenticRun already exists for the first alert
-- **THEN** the second alert produces the same `agentic.openshift.io/alert-fingerprint` label value, `hasActiveRun` matches the existing AgenticRun, and no new AgenticRun is created
+- **THEN** the second alert produces the same `agentic.openshift.io/alert-dedup-fingerprint` label value, `hasActiveRun` matches the existing AgenticRun, and no new AgenticRun is created
 
 ### Requirement: Sanitize alert data for Kubernetes metadata
 The system SHALL sanitize alert values to conform to Kubernetes naming and label restrictions.


### PR DESCRIPTION
The alert-fingerprint label now stores the original AlertManager fingerprint (truncated to 8 chars) for UI lookups, while a new alert-dedup-fingerprint label stores the stable fingerprint used for deduplication. Export label/annotation key constants from the agenticrun package.


Assisted-by: Claude Code:claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a stable, configurable alert fingerprint for reliable run deduplication.
  - Preserved the original Alertmanager fingerprint for display and lookups.
  - Generated runs now include both fingerprint values.

- **Bug Fixes**
  - Improved deduplication consistency when alert fingerprints change or are truncated.

- **Documentation**
  - Clarified the distinct purposes of the original and deduplication fingerprints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->