### PR TITLE
fix: add arm64 to the build platforms

### DIFF
--- a/.tekton/lightspeed-agentic-alerts-adapter-pull-request.yaml
+++ b/.tekton/lightspeed-agentic-alerts-adapter-pull-request.yaml
@@ -29,6 +29,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Containerfile
   - name: hermetic

--- a/.tekton/lightspeed-agentic-alerts-adapter-push.yaml
+++ b/.tekton/lightspeed-agentic-alerts-adapter-push.yaml
@@ -26,6 +26,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Containerfile
   - name: hermetic


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container images are now built for both `linux/x86_64` and `linux/arm64` platforms in pull request and push pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->