### PR TITLE
OBSINTA-1595: scope alerts adapter RBAC to openshift-lightspeed namespace

### DIFF
--- a/cmd/alerts-adapter/main.go
+++ b/cmd/alerts-adapter/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	runClient := agenticrun.NewClient(k8sClient, namespace, logger)
 
-	a := adapter.New(amClient, runClient, cfg, logger)
+	a := adapter.New(amClient, runClient, cfg, namespace, logger)
 	if err := a.Run(ctx); err != nil {
 		logger.Error("fatal error", "error", err)
 		os.Exit(1)

--- a/cmd/alerts-adapter/main.go
+++ b/cmd/alerts-adapter/main.go
@@ -48,7 +48,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	runClient := agenticrun.NewClient(k8sClient, logger)
+	namespace := os.Getenv("POD_NAMESPACE")
+	if namespace == "" {
+		namespace = agenticrun.RunNamespace
+	}
+
+	runClient := agenticrun.NewClient(k8sClient, namespace, logger)
 
 	a := adapter.New(amClient, runClient, cfg, logger)
 	if err := a.Run(ctx); err != nil {

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -32,20 +32,22 @@ type AgenticRunClient interface {
 // applying stateless deduplication (pre-run delay, active-run check,
 // and post-run delay) on each cycle.
 type Adapter struct {
-	alerts   AlertSource
-	arClient AgenticRunClient
-	cfg      config.Config
-	logger   *slog.Logger
+	alerts    AlertSource
+	arClient  AgenticRunClient
+	cfg       config.Config
+	namespace string
+	logger    *slog.Logger
 }
 
 // New creates an Adapter with the given alert source, run client,
-// config, and logger.
-func New(alerts AlertSource, arClient AgenticRunClient, cfg config.Config, logger *slog.Logger) *Adapter {
+// config, namespace, and logger.
+func New(alerts AlertSource, arClient AgenticRunClient, cfg config.Config, namespace string, logger *slog.Logger) *Adapter {
 	return &Adapter{
-		alerts:   alerts,
-		arClient: arClient,
-		cfg:      cfg,
-		logger:   logger,
+		alerts:    alerts,
+		arClient:  arClient,
+		cfg:       cfg,
+		namespace: namespace,
+		logger:    logger,
 	}
 }
 
@@ -157,7 +159,7 @@ func (a *Adapter) reconcile(ctx context.Context) {
 			continue
 		}
 
-		p, err := agenticrun.Build(alert, a.cfg.Tools, a.cfg.Agent, a.cfg.IgnoredLabels)
+		p, err := agenticrun.Build(alert, a.cfg.Tools, a.cfg.Agent, a.cfg.IgnoredLabels, a.namespace)
 		if err != nil {
 			a.logger.Error("failed to build run",
 				"alertname", alertName,

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -287,10 +287,11 @@ func TestReconcile(t *testing.T) {
 			rc := &fakeRunClient{runs: tt.runs, listErr: tt.runsErr, createErr: tt.createErr, wasCreated: tt.wasCreated}
 
 			a := &Adapter{
-				alerts: as,
-				arClient: rc,
-				cfg:    defaultTestConfig(),
-				logger: quietLogger(),
+				alerts:    as,
+				arClient:  rc,
+				cfg:       defaultTestConfig(),
+				namespace: agenticrun.RunNamespace,
+				logger:    quietLogger(),
 			}
 
 			a.reconcile(context.Background())
@@ -454,10 +455,11 @@ func TestReconcileSkipsSeverity(t *testing.T) {
 			rc := &fakeRunClient{}
 
 			a := &Adapter{
-				alerts: as,
-				arClient: rc,
-				cfg:    defaultTestConfig(),
-				logger: quietLogger(),
+				alerts:    as,
+				arClient:  rc,
+				cfg:       defaultTestConfig(),
+				namespace: agenticrun.RunNamespace,
+				logger:    quietLogger(),
 			}
 
 			a.reconcile(context.Background())
@@ -484,10 +486,11 @@ func TestReconcileWithTools(t *testing.T) {
 		}
 
 		a := &Adapter{
-			alerts: as,
-			arClient: rc,
-			cfg:    cfg,
-			logger: quietLogger(),
+			alerts:    as,
+			arClient:  rc,
+			cfg:       cfg,
+			namespace: agenticrun.RunNamespace,
+			logger:    quietLogger(),
 		}
 
 		a.reconcile(context.Background())
@@ -518,10 +521,11 @@ func TestReconcileWithTools(t *testing.T) {
 		}
 
 		a := &Adapter{
-			alerts: as,
-			arClient: rc,
-			cfg:    cfg,
-			logger: quietLogger(),
+			alerts:    as,
+			arClient:  rc,
+			cfg:       cfg,
+			namespace: agenticrun.RunNamespace,
+			logger:    quietLogger(),
 		}
 
 		a.reconcile(context.Background())
@@ -595,7 +599,7 @@ func TestReconcileZeroDelays(t *testing.T) {
 			cfg.PreRunDelay = tt.preRunDelay
 			cfg.PostRunDelay = tt.postRunDelay
 
-			a := &Adapter{alerts: as, arClient: rc, cfg: cfg, logger: quietLogger()}
+			a := &Adapter{alerts: as, arClient: rc, cfg: cfg, namespace: agenticrun.RunNamespace, logger: quietLogger()}
 			a.reconcile(context.Background())
 
 			if rc.createCalls != 1 {
@@ -621,10 +625,11 @@ func TestReconcileDedupsWithinSameCycle(t *testing.T) {
 	rc := &fakeRunClient{}
 
 	a := &Adapter{
-		alerts:   as,
-		arClient: rc,
-		cfg:      defaultTestConfig(),
-		logger:   quietLogger(),
+		alerts:    as,
+		arClient:  rc,
+		cfg:       defaultTestConfig(),
+		namespace: agenticrun.RunNamespace,
+		logger:    quietLogger(),
 	}
 
 	a.reconcile(context.Background())

--- a/internal/agenticrun/build.go
+++ b/internal/agenticrun/build.go
@@ -68,7 +68,7 @@ type requestData struct {
 // safe against duplicate creation via Kubernetes 409 AlreadyExists.
 // Different occurrences of the same alert (different startsAt) produce
 // distinct AgenticRun names, allowing re-creation after cooldown.
-func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.AgentConfig, ignoredLabels []string) (*agenticv1alpha1.AgenticRun, error) {
+func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.AgentConfig, ignoredLabels []string, targetNamespace string) (*agenticv1alpha1.AgenticRun, error) {
 	if a.Fingerprint == nil {
 		return nil, fmt.Errorf("agenticrun: alert fingerprint is nil")
 	}
@@ -110,7 +110,7 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        buildName(alertName, namespace, startsAt),
-			Namespace:   RunNamespace,
+			Namespace:   targetNamespace,
 			Labels:      buildLabels(alertName, severity, originalFP, stableFP),
 			Annotations: buildAnnotations(a),
 		},

--- a/internal/agenticrun/build.go
+++ b/internal/agenticrun/build.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	runNamespace = "openshift-lightspeed"
+	RunNamespace = "openshift-lightspeed"
 	defaultAgent = "default"
 
 	LabelSource           = "agentic.openshift.io/source"
@@ -110,7 +110,7 @@ func Build(a *models.GettableAlert, tools config.ToolsConfig, agent config.Agent
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        buildName(alertName, namespace, startsAt),
-			Namespace:   runNamespace,
+			Namespace:   RunNamespace,
 			Labels:      buildLabels(alertName, severity, originalFP, stableFP),
 			Annotations: buildAnnotations(a),
 		},

--- a/internal/agenticrun/build_test.go
+++ b/internal/agenticrun/build_test.go
@@ -54,7 +54,7 @@ func TestBuild(t *testing.T) {
 			alert:             makeAlert("KubePodCrashLooping", "production", "abcdef1234567890", "critical"),
 			ignoredLabels:     noIgnored,
 			expectedName:      "kubepodcrashlooping-production-895c8977",
-			expectedNamespace: runNamespace,
+			expectedNamespace: RunNamespace,
 			expectedTargetNS:  []string{"production"},
 			expectedLabels: map[string]string{
 				LabelSource:      sourceValue,
@@ -77,7 +77,7 @@ func TestBuild(t *testing.T) {
 			}(),
 			ignoredLabels:     noIgnored,
 			expectedName:      "clusterversionavailable-895c8977",
-			expectedNamespace: runNamespace,
+			expectedNamespace: RunNamespace,
 			expectedTargetNS:  nil,
 			expectedLabels: map[string]string{
 				LabelSource:      sourceValue,
@@ -95,7 +95,7 @@ func TestBuild(t *testing.T) {
 			alert:             makeAlert("TestAlert", "ns", "abc", "warning"),
 			ignoredLabels:     []string{"pod", "instance"},
 			expectedName:      "testalert-ns-895c8977",
-			expectedNamespace: runNamespace,
+			expectedNamespace: RunNamespace,
 			expectedTargetNS:  []string{"ns"},
 			expectedLabels: map[string]string{
 				LabelSource:      sourceValue,

--- a/internal/agenticrun/build_test.go
+++ b/internal/agenticrun/build_test.go
@@ -113,7 +113,7 @@ func TestBuild(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := Build(tt.alert, config.ToolsConfig{}, config.AgentConfig{}, tt.ignoredLabels)
+			p, err := Build(tt.alert, config.ToolsConfig{}, config.AgentConfig{}, tt.ignoredLabels, RunNamespace)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -152,7 +152,7 @@ func TestBuildNilFingerprint(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
 	a.Fingerprint = nil
 
-	_, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	_, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err == nil {
 		t.Fatal("expected error for nil fingerprint, got nil")
 	}
@@ -167,7 +167,7 @@ func TestBuildNilStartsAt(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
 	a.StartsAt = nil
 
-	_, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	_, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err == nil {
 		t.Fatal("expected error for nil startsAt, got nil")
 	}
@@ -180,7 +180,7 @@ func TestBuildNilStartsAt(t *testing.T) {
 
 func TestBuildWorkflowSteps(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -199,11 +199,11 @@ func TestBuildWorkflowSteps(t *testing.T) {
 func TestBuildDeterministicNaming(t *testing.T) {
 	a := makeAlert("KubePodCrashLooping", "production", "abcdef1234567890", "critical")
 
-	p1, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	p1, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err != nil {
 		t.Fatalf("first build: %v", err)
 	}
-	p2, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	p2, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err != nil {
 		t.Fatalf("second build: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestBuildDeterministicNaming(t *testing.T) {
 func TestBuildAnnotations(t *testing.T) {
 	t.Run("starts-at is RFC3339 UTC", func(t *testing.T) {
 		a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -229,7 +229,7 @@ func TestBuildAnnotations(t *testing.T) {
 
 	t.Run("summary is included", func(t *testing.T) {
 		a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -244,7 +244,7 @@ func TestBuildAnnotations(t *testing.T) {
 		startsAt := strfmt.DateTime(time.Time{})
 		a.StartsAt = &startsAt
 
-		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -260,7 +260,7 @@ func TestBuildAnnotations(t *testing.T) {
 		a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
 		a.Annotations["summary"] = strings.Repeat("x", 300)
 
-		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -274,7 +274,7 @@ func TestBuildRequest(t *testing.T) {
 	a := makeAlert("KubePodCrashLooping", "production", "abcdef12", "critical")
 	a.Annotations["runbook_url"] = "https://runbooks.example.com/KubePodCrashLooping"
 
-	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -295,7 +295,7 @@ func TestBuildRequestWithSkillPaths(t *testing.T) {
 	a := makeAlert("KubePodCrashLooping", "production", "abcdef12", "critical")
 
 	t.Run("no shared skills omits skill paths", func(t *testing.T) {
-		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -313,7 +313,7 @@ func TestBuildRequestWithSkillPaths(t *testing.T) {
 				}},
 			},
 		}
-		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		p, err := Build(a, tc, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -335,7 +335,7 @@ func TestBuildRequestWithSkillPaths(t *testing.T) {
 				{Image: "registry.example.com/skills-b:latest", Paths: []string{"/skills/beta"}},
 			},
 		}
-		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		p, err := Build(a, tc, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -353,7 +353,7 @@ func TestBuildRequestWithSkillPaths(t *testing.T) {
 
 func TestBuildRequestWithoutRunbook(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -611,7 +611,7 @@ func TestBuildRequestSanitizesAdversarialContent(t *testing.T) {
 				a.Labels[k] = v
 			}
 
-			p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+			p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -632,7 +632,7 @@ func TestBuildRequestSanitizesAdversarialContent(t *testing.T) {
 
 func TestBuildTypeMeta(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
-	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+	p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -649,7 +649,7 @@ func TestBuildWithTools(t *testing.T) {
 	a := makeAlert("TestAlert", "ns", "abcdef12", "warning")
 
 	t.Run("empty tools config omits all tools", func(t *testing.T) {
-		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil)
+		p, err := Build(a, config.ToolsConfig{}, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -673,7 +673,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/skills:latest", Paths: []string{"/skills/prometheus"}},
 			},
 		}
-		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		p, err := Build(a, tc, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -706,7 +706,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/verify:latest", Paths: []string{"/skills/validation"}},
 			},
 		}
-		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		p, err := Build(a, tc, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -742,7 +742,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/analysis:latest", Paths: []string{"/skills/diagnostic"}},
 			},
 		}
-		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		p, err := Build(a, tc, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -772,7 +772,7 @@ func TestBuildWithTools(t *testing.T) {
 				{Image: "registry.example.com/analysis:latest", Paths: []string{"/skills/diagnostic"}},
 			},
 		}
-		p, err := Build(a, tc, config.AgentConfig{}, nil)
+		p, err := Build(a, tc, config.AgentConfig{}, nil, RunNamespace)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -944,7 +944,7 @@ func TestBuildWithAgentOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := Build(a, config.ToolsConfig{}, tt.agent, nil)
+			p, err := Build(a, config.ToolsConfig{}, tt.agent, nil, RunNamespace)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/agenticrun/client.go
+++ b/internal/agenticrun/client.go
@@ -13,19 +13,20 @@ import (
 // Client creates and lists AgenticRun resources in the cluster.
 type Client struct {
 	client.Client
-	logger *slog.Logger
+	namespace string
+	logger    *slog.Logger
 }
 
 // NewClient creates a Client that wraps the given controller-runtime client.
-func NewClient(c client.Client, logger *slog.Logger) *Client {
-	return &Client{Client: c, logger: logger}
+func NewClient(c client.Client, namespace string, logger *slog.Logger) *Client {
+	return &Client{Client: c, namespace: namespace, logger: logger}
 }
 
 // ListAgenticRuns returns all AgenticRuns created by this adapter, filtered by the
 // source=alertmanager label.
 func (c *Client) ListAgenticRuns(ctx context.Context) ([]agenticv1alpha1.AgenticRun, error) {
 	var list agenticv1alpha1.AgenticRunList
-	if err := c.List(ctx, &list, client.MatchingLabels{LabelSource: sourceValue}); err != nil {
+	if err := c.List(ctx, &list, client.InNamespace(c.namespace), client.MatchingLabels{LabelSource: sourceValue}); err != nil {
 		return nil, fmt.Errorf("agenticrun: listing runs: %w", err)
 	}
 	return list.Items, nil

--- a/internal/agenticrun/client_test.go
+++ b/internal/agenticrun/client_test.go
@@ -21,7 +21,7 @@ func newTestClient(t *testing.T) *Client {
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return &Client{Client: fc, logger: logger}
+	return &Client{Client: fc, namespace: RunNamespace, logger: logger}
 }
 
 func TestCreateAgenticRun(t *testing.T) {
@@ -30,7 +30,7 @@ func TestCreateAgenticRun(t *testing.T) {
 	p := &agenticv1alpha1.AgenticRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-run-abcdef12",
-			Namespace: runNamespace,
+			Namespace: RunNamespace,
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{
 			Request:  "test request",
@@ -63,7 +63,7 @@ func TestCreateAgenticRunAlreadyExists(t *testing.T) {
 	p := &agenticv1alpha1.AgenticRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-run-abcdef12",
-			Namespace: runNamespace,
+			Namespace: RunNamespace,
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{
 			Request:  "test request",
@@ -78,7 +78,7 @@ func TestCreateAgenticRunAlreadyExists(t *testing.T) {
 	duplicate := &agenticv1alpha1.AgenticRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-run-abcdef12",
-			Namespace: runNamespace,
+			Namespace: RunNamespace,
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{
 			Request:  "test request",
@@ -100,7 +100,7 @@ func TestListAgenticRuns(t *testing.T) {
 	matching := &agenticv1alpha1.AgenticRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "matching-abcdef12",
-			Namespace: runNamespace,
+			Namespace: RunNamespace,
 			Labels:    map[string]string{LabelSource: sourceValue},
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{
@@ -111,7 +111,7 @@ func TestListAgenticRuns(t *testing.T) {
 	unrelated := &agenticv1alpha1.AgenticRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "unrelated-12345678",
-			Namespace: runNamespace,
+			Namespace: RunNamespace,
 			Labels:    map[string]string{LabelSource: "other"},
 		},
 		Spec: agenticv1alpha1.AgenticRunSpec{

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,20 +1,22 @@
-# AgenticRuns: create and list AgenticRun CRs cluster-wide.
+# AgenticRuns: create and list AgenticRun CRs in openshift-lightspeed.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: lightspeed-agentic-alerts-adapter-agenticruns
+  namespace: openshift-lightspeed
 rules:
   - apiGroups: ["agentic.openshift.io"]
     resources: ["agenticruns"]
     verbs: ["create", "list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: lightspeed-agentic-alerts-adapter-agenticruns
+  namespace: openshift-lightspeed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: lightspeed-agentic-alerts-adapter-agenticruns
 subjects:
   - kind: ServiceAccount

--- a/openspec/changes/add-openshift-manifests/design.md
+++ b/openspec/changes/add-openshift-manifests/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-The adapter is a stateless Go binary that polls AlertManager and creates AgenticRun CRs. ARCHITECTURE.md already specifies the intended Kubernetes resources (Deployment, ServiceAccount, RBAC), but no actual manifest files exist. The adapter runs as a single-replica Deployment in the `openshift-lightspeed` namespace, uses in-cluster ServiceAccount authentication, and needs cross-namespace RBAC for both AlertManager reads and AgenticRun writes.
+The adapter is a stateless Go binary that polls AlertManager and creates AgenticRun CRs. ARCHITECTURE.md already specifies the intended Kubernetes resources (Deployment, ServiceAccount, RBAC), but no actual manifest files exist. The adapter runs as a single-replica Deployment in the `openshift-lightspeed` namespace, uses in-cluster ServiceAccount authentication, and needs RBAC for both AlertManager reads (cross-namespace) and AgenticRun writes (namespaced to `openshift-lightspeed`).
 
 ## Goals / Non-Goals
 
@@ -23,7 +23,7 @@ Use a flat `manifests/` directory with plain YAML files, applied directly with `
 
 ### Group related resources into single files
 
-Tightly coupled resources (e.g. ClusterRole + ClusterRoleBinding) go in the same file, separated by `---`. This keeps related definitions together and reduces file count without sacrificing clarity. Independent resources (Namespace, ServiceAccount, Deployment) get their own files.
+Tightly coupled resources (e.g. Role + RoleBinding) go in the same file, separated by `---`. This keeps related definitions together and reduces file count without sacrificing clarity. Independent resources (Namespace, ServiceAccount, Deployment) get their own files.
 
 ### Namespace resource included
 
@@ -33,4 +33,4 @@ Include a `namespace.yaml` that creates `openshift-lightspeed`. This makes the m
 
 - **Image tag `latest`**: The ARCHITECTURE.md example uses `latest`. This is fine for development but should be pinned to a specific digest or tag for production. This is a future concern, not in scope for this change.
 - **`monitoring-alertmanager-view` Role must pre-exist**: The RoleBinding references a Role provided by the OpenShift monitoring stack. If the monitoring stack is not installed, the RoleBinding will fail. This is documented as a prerequisite.
-- **AgenticRun CRD must pre-exist**: The ClusterRole references `agenticruns` in the `agentic.openshift.io` API group. The CRD must be installed (via the lightspeed-agentic-operator) before the adapter's RBAC is meaningful.
+- **AgenticRun CRD must pre-exist**: The Role references `agenticruns` in the `agentic.openshift.io` API group. The CRD must be installed (via the lightspeed-agentic-operator) before the adapter's RBAC is meaningful.

--- a/openspec/changes/add-openshift-manifests/proposal.md
+++ b/openspec/changes/add-openshift-manifests/proposal.md
@@ -5,7 +5,7 @@ The adapter has no deployment manifests yet. The ARCHITECTURE.md defines the int
 ## What Changes
 
 - Add a `manifests/` directory with all Kubernetes/OpenShift resource definitions needed to deploy the adapter.
-- Include: Namespace, ServiceAccount, Deployment, RBAC (RoleBinding for AlertManager access, ClusterRole + ClusterRoleBinding for AgenticRun management).
+- Include: Namespace, ServiceAccount, Deployment, RBAC (RoleBinding for AlertManager access, Role + RoleBinding for AgenticRun management in `openshift-lightspeed`).
 - Follow the resource specifications already defined in ARCHITECTURE.md.
 
 ## Capabilities

--- a/openspec/changes/add-openshift-manifests/specs/cluster-deployment/spec.md
+++ b/openspec/changes/add-openshift-manifests/specs/cluster-deployment/spec.md
@@ -44,12 +44,12 @@ The manifests SHALL include a RoleBinding in the `openshift-monitoring` namespac
 - **THEN** a RoleBinding named `lightspeed-agentic-alerts-adapter-alertmanager` SHALL exist in `openshift-monitoring` binding the `monitoring-alertmanager-view` Role to the adapter's ServiceAccount
 
 ### Requirement: AgenticRun RBAC
-The manifests SHALL include a ClusterRole and ClusterRoleBinding in a single file that grant the adapter's ServiceAccount permissions to `create`, `list`, and `get` resources of type `agenticruns` in the `agentic.openshift.io` API group across all namespaces.
+The manifests SHALL include a Role and RoleBinding in the `openshift-lightspeed` namespace in a single file that grant the adapter's ServiceAccount permissions to `create`, `list`, and `get` resources of type `agenticruns` in the `agentic.openshift.io` API group.
 
-#### Scenario: AgenticRun ClusterRole
+#### Scenario: AgenticRun Role
 - **WHEN** the manifests are applied
-- **THEN** a ClusterRole named `lightspeed-agentic-alerts-adapter-agenticruns` SHALL exist with `create`, `list`, `get` verbs on `agenticruns` in the `agentic.openshift.io` API group
+- **THEN** a Role named `lightspeed-agentic-alerts-adapter-agenticruns` SHALL exist in the `openshift-lightspeed` namespace with `create`, `list`, `get` verbs on `agenticruns` in the `agentic.openshift.io` API group
 
-#### Scenario: AgenticRun ClusterRoleBinding
+#### Scenario: AgenticRun RoleBinding
 - **WHEN** the manifests are applied
-- **THEN** a ClusterRoleBinding SHALL bind the ClusterRole to the adapter's ServiceAccount in `openshift-lightspeed`
+- **THEN** a RoleBinding in the `openshift-lightspeed` namespace SHALL bind the Role to the adapter's ServiceAccount

--- a/openspec/changes/add-openshift-manifests/tasks.md
+++ b/openspec/changes/add-openshift-manifests/tasks.md
@@ -6,7 +6,7 @@
 ## 2. RBAC
 
 - [x] 2.1 Create `manifests/rolebinding-alertmanager.yaml` with the RoleBinding in `openshift-monitoring` granting `monitoring-alertmanager-view` to the adapter's ServiceAccount
-- [x] 2.2 Create `manifests/clusterrole-agenticruns.yaml` with the ClusterRole and ClusterRoleBinding (separated by `---`) granting create/list/get on `agenticruns` in `agentic.openshift.io` and binding it to the adapter's ServiceAccount
+- [x] 2.2 Create `manifests/rbac.yaml` with the Role and RoleBinding in `openshift-lightspeed` (separated by `---`) granting create/list/get on `agenticruns` in `agentic.openshift.io` and binding it to the adapter's ServiceAccount
 
 ## 3. Deployment
 


### PR DESCRIPTION
Replace ClusterRole/ClusterRoleBinding with namespaced Role/RoleBinding for AgenticRun access. The adapter only creates and lists AgenticRuns in openshift-lightspeed, so cluster-wide RBAC is unnecessarily permissive.

Ref: [OBSINTA-1595](https://redhat.atlassian.net/browse/OBSINTA-1595)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AgenticRun operations now target the configured pod namespace, with a default used when no environment value is provided.
  * AgenticRun discovery is limited to the selected namespace.

* **Security**
  * AgenticRun permissions are restricted to the application namespace instead of applying cluster-wide.

* **Documentation**
  * Deployment guidance and requirements now reflect namespace-scoped permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->