### PR TITLE
OBSINTA-1633: rename the dedup-fingerprint label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Three internal packages, each behind an interface, wired together in `cmd/alerts
 
 - **`internal/alertmanager`** — AlertManager API client. Reads bearer token on every call (handles rotation). TLS via in-cluster CA. Implements `adapter.AlertSource`.
 - **`internal/agenticrun`** — Two concerns: `build.go` translates an alert into an `AgenticRun` CR (deterministic name from alertname, namespace, and startsAt hash; embedded Go template `request.tmpl` for the request field); `client.go` wraps controller-runtime to create/list AgenticRuns. Implements `adapter.AgenticRunClient`.
-- **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `preRunDelay` (default 0s), with an active (non-terminal) AgenticRun, or within `postRunDelay` (default 1h) of a terminal AgenticRun. Matching is by `alert-dedup-fingerprint` label (stable FNV-64a hash of labels minus configurable ignored labels).
+- **`internal/adapter`** — Poll loop (`Run` → `reconcile` on ticker). Stateless deduplication: skips alerts below `preRunDelay` (default 0s), with an active (non-terminal) AgenticRun, or within `postRunDelay` (default 1h) of a terminal AgenticRun. Matching is by `alert-group-id` label (stable FNV-64a hash of labels minus configurable ignored labels).
 
 The AgenticRun CRD types come from `github.com/openshift/lightspeed-agentic-operator/api`.
 
@@ -36,7 +36,7 @@ The AgenticRun CRD types come from `github.com/openshift/lightspeed-agentic-oper
 - Polls (not webhooks) for resilience — restart immediately sees all firing alerts.
 - AgenticRuns always created in `openshift-lightspeed` namespace.
 - 409 AlreadyExists on create is expected and handled as a no-op (returns `false, nil`).
-- Two fingerprints on each AgenticRun CR: `alert-fingerprint` stores the original AlertManager fingerprint (for UI lookups by alert), `alert-dedup-fingerprint` stores the stable fingerprint (FNV-64a[:8] of sorted labels minus configurable ignored labels, used for dedup matching). Default ignored labels: `pod`, `instance`, `endpoint`, `uid`. Configurable via `deduplication.ignoredLabels` in the ConfigMap. AgenticRun names use a hash of the alert's `startsAt` timestamp for uniqueness.
+- Two fingerprints on each AgenticRun CR: `alert-fingerprint` stores the original AlertManager fingerprint (for UI lookups by alert), `alert-group-id` stores the stable fingerprint (FNV-64a[:8] of sorted labels minus configurable ignored labels, used for dedup matching). Default ignored labels: `pod`, `instance`, `endpoint`, `uid`. Configurable via `deduplication.ignoredLabels` in the ConfigMap. AgenticRun names use a hash of the alert's `startsAt` timestamp for uniqueness.
 - Terminal phases: Completed, Failed, Denied, Escalated.
 - `preRunDelay` (default 0s) and `postRunDelay` (default 1h) are clamped to 0 for zero or negative values. Both can be explicitly set to `0s` to disable the delay. Invalid duration syntax causes a config load error.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,7 +127,7 @@ Examples:
 
 Components are sanitized to conform to DNS subdomain rules (RFC 1123): lowercased, non-alphanumeric characters replaced, truncated to fit the 63-character limit.
 
-Deduplication uses the `alert-dedup-fingerprint` label (stable FNV-64a hash of labels minus configurable ignored labels, truncated to 8 hex characters) to match alerts to existing AgenticRuns. The original AlertManager fingerprint is stored separately in the `alert-fingerprint` label for UI lookups. Neither fingerprint is part of the AgenticRun name — they are only stored as labels for matching.
+Deduplication uses the `alert-group-id` label (stable FNV-64a hash of labels minus configurable ignored labels, truncated to 8 hex characters) to match alerts to existing AgenticRuns. The original AlertManager fingerprint is stored separately in the `alert-fingerprint` label for UI lookups. Neither fingerprint is part of the AgenticRun name — they are only stored as labels for matching.
 
 ### Alert to AgenticRun Mapping
 
@@ -205,7 +205,7 @@ metadata:
   labels:
     agentic.openshift.io/source: alertmanager
     agentic.openshift.io/alert-fingerprint: <AlertManager fingerprint[:8]>
-    agentic.openshift.io/alert-dedup-fingerprint: <stable fingerprint[:8]>
+    agentic.openshift.io/alert-group-id: <stable fingerprint[:8]>
     agentic.openshift.io/alert-name: <alertname, lowercased>
     agentic.openshift.io/alert-severity: <severity>
   annotations:

--- a/internal/agenticrun/build.go
+++ b/internal/agenticrun/build.go
@@ -29,7 +29,7 @@ const (
 
 	LabelSource           = "agentic.openshift.io/source"
 	LabelFingerprint      = "agentic.openshift.io/alert-fingerprint"
-	LabelDedupFingerprint = "agentic.openshift.io/alert-dedup-fingerprint"
+	LabelDedupFingerprint = "agentic.openshift.io/alert-group-id"
 	LabelAlertName        = "agentic.openshift.io/alert-name"
 	LabelSeverity         = "agentic.openshift.io/alert-severity"
 	AnnotStartsAt         = "agentic.openshift.io/alert-starts-at"
@@ -38,8 +38,8 @@ const (
 	sourceValue = "alertmanager"
 
 	maxLabelValueLen = 63
-	fingerprintLen = 8
-	maxSummaryLen  = 256
+	fingerprintLen   = 8
+	maxSummaryLen    = 256
 )
 
 var (
@@ -49,7 +49,7 @@ var (
 
 	//go:embed request.tmpl
 	requestTemplateStr string
-	requestTemplate = template.Must(template.New("request").Parse(requestTemplateStr))
+	requestTemplate    = template.Must(template.New("request").Parse(requestTemplateStr))
 )
 
 type requestData struct {
@@ -174,11 +174,11 @@ func startsAtHash(t time.Time) string {
 // buildLabels sets Kubernetes labels for alert traceability and filtering.
 func buildLabels(alertName, severity, originalFingerprint, stableFingerprint string) map[string]string {
 	return map[string]string{
-		LabelSource:            sourceValue,
-		LabelFingerprint:       sanitizeLabelValue(originalFingerprint[:min(len(originalFingerprint), fingerprintLen)]),
+		LabelSource:           sourceValue,
+		LabelFingerprint:      sanitizeLabelValue(originalFingerprint[:min(len(originalFingerprint), fingerprintLen)]),
 		LabelDedupFingerprint: stableFingerprint,
-		LabelAlertName:         sanitizeLabelValue(strings.ToLower(alertName)),
-		LabelSeverity:          sanitizeLabelValue(severity),
+		LabelAlertName:        sanitizeLabelValue(strings.ToLower(alertName)),
+		LabelSeverity:         sanitizeLabelValue(severity),
 	}
 }
 

--- a/openspec/changes/e2e-tests/design.md
+++ b/openspec/changes/e2e-tests/design.md
@@ -22,7 +22,7 @@ E2E tests on a real OpenShift cluster with live AlertManager and operator are ne
 **Goals:**
 - Validate the full reconciliation loop on a live OpenShift cluster: real firing alert → adapter processes → AgenticRun created → live operator reconciles it.
 - Test deduplication logic end-to-end: verify alerts are correctly skipped based on severity, receiver filtering, pre-run delay, active AgenticRun presence, and post-run delay.
-- Verify `alert-fingerprint` and `alert-dedup-fingerprint` labels are set correctly on created AgenticRun CRs.
+- Verify `alert-fingerprint` and `alert-group-id` labels are set correctly on created AgenticRun CRs.
 - Verify ConfigMap changes are picked up by the adapter on the next poll cycle (no restart required).
 - Test error handling: AlertManager unreachable, Kubernetes API errors.
 - Tests run in OpenShift CI on a provisioned cluster and locally via `make test-e2e` (requires `oc login` to a cluster).
@@ -84,7 +84,7 @@ E2E tests on a real OpenShift cluster with live AlertManager and operator are ne
 **Decision:** E2E tests will cover:
 1. **Happy path:** Firing alert (routed to configured receiver) → AgenticRun created with correct labels
 2. **Deduplication:** Alerts skipped due to severity `info`/`none`, receiver not in allowlist, active AgenticRun, within `postRunDelay` of terminal AgenticRun
-3. **Fingerprint labels:** Verify `alert-fingerprint` and `alert-dedup-fingerprint` are set correctly
+3. **Fingerprint labels:** Verify `alert-fingerprint` and `alert-group-id` are set correctly
 4. **Error handling:** 409 AlreadyExists on AgenticRun create is no-op (logged at Info level)
 
 **Rationale:** These scenarios cover the critical integration points and most common failure modes.

--- a/openspec/changes/e2e-tests/specs/e2e-tests/spec.md
+++ b/openspec/changes/e2e-tests/specs/e2e-tests/spec.md
@@ -32,7 +32,7 @@ The E2E test suite SHALL validate that a firing alert routed to a configured rec
 #### Scenario: Firing alert creates AgenticRun
 - **GIVEN** a firing alert with severity `warning` is injected into all AlertManager replicas via the `/api/v2/alerts` API and routed to receiver `default`
 - **WHEN** the adapter polls AlertManager
-- **THEN** an AgenticRun CR is created in the `openshift-lightspeed` namespace with labels `alert-fingerprint` and `alert-dedup-fingerprint`
+- **THEN** an AgenticRun CR is created in the `openshift-lightspeed` namespace with labels `alert-fingerprint` and `alert-group-id`
 
 ### Requirement: Deduplication behavior
 The E2E test suite SHALL verify that alerts are correctly skipped based on adapter's deduplication filters (severity, receiver, pre-run delay, active AgenticRun, post-run delay).
@@ -53,7 +53,7 @@ The E2E test suite SHALL verify that alerts are correctly skipped based on adapt
 - **THEN** no AgenticRun is created for this alert
 
 #### Scenario: Alert with active AgenticRun is skipped
-- **GIVEN** an AgenticRun with phase `Analyzing` and label `alert-dedup-fingerprint: X` and label `source: alerts-adapter` exists
+- **GIVEN** an AgenticRun with phase `Analyzing` and label `alert-group-id: X` and label `source: alerts-adapter` exists
 - **WHEN** the adapter polls and finds a firing alert with dedup fingerprint X routed to `default`
 - **THEN** no additional AgenticRun is created
 
@@ -68,17 +68,17 @@ The E2E test suite SHALL verify that alerts are correctly skipped based on adapt
 - **THEN** a new AgenticRun is created
 
 ### Requirement: Fingerprint labels
-The E2E test suite SHALL verify that created AgenticRun CRs have both `alert-fingerprint` (original AlertManager fingerprint) and `alert-dedup-fingerprint` (stable fingerprint computed from labels minus ignored labels) labels set correctly.
+The E2E test suite SHALL verify that created AgenticRun CRs have both `alert-fingerprint` (original AlertManager fingerprint) and `alert-group-id` (stable fingerprint computed from labels minus ignored labels) labels set correctly.
 
 #### Scenario: Fingerprint labels are set
 - **GIVEN** AlertManager returns a firing alert with fingerprint `abc123` and labels including `alertname`, `namespace`, `pod`
 - **WHEN** the adapter creates an AgenticRun
-- **THEN** the AgenticRun has label `alert-fingerprint: abc123` and label `alert-dedup-fingerprint: <computed-hash>` (non-empty)
+- **THEN** the AgenticRun has label `alert-fingerprint: abc123` and label `alert-group-id: <computed-hash>` (non-empty)
 
 #### Scenario: Dedup fingerprint ignores configured labels
 - **GIVEN** the adapter config has `deduplication.ignoredLabels: [pod, instance, endpoint, uid]` and two alerts differ only in `pod` label
 - **WHEN** the adapter processes both alerts
-- **THEN** the first alert creates an AgenticRun with `alert-dedup-fingerprint: X`, and the second alert is skipped (because it would produce the same fingerprint X, proving deduplication works)
+- **THEN** the first alert creates an AgenticRun with `alert-group-id: X`, and the second alert is skipped (because it would produce the same fingerprint X, proving deduplication works)
 
 ### Requirement: Error handling
 The E2E test suite SHALL verify that the adapter handles expected errors gracefully (409 AlreadyExists, transient failures).

--- a/openspec/changes/e2e-tests/tasks.md
+++ b/openspec/changes/e2e-tests/tasks.md
@@ -25,7 +25,7 @@
 - [x] 3.2 Test: verify adapter deployment is available and pods are running
 - [x] ~3.3 Test: query AlertManager for firing alerts~ — skipped: tests inject alerts explicitly via AlertManager API, making this precondition check redundant
 - [x] 3.4 Test: wait for adapter to create AgenticRun for injected alert (poll for AgenticRun with alert-name label)
-- [x] 3.5 Test: verify AgenticRun has correct labels (alert-fingerprint, alert-dedup-fingerprint)
+- [x] 3.5 Test: verify AgenticRun has correct labels (alert-fingerprint, alert-group-id)
 
 
 ## 4. Deduplication Tests
@@ -40,7 +40,7 @@
 
 ## 5. Fingerprint Tests
 
-- [x] 5.1 Test: verify AgenticRun has both `alert-fingerprint` and `alert-dedup-fingerprint` labels (covered in 3.5)
+- [x] 5.1 Test: verify AgenticRun has both `alert-fingerprint` and `alert-group-id` labels (covered in 3.5)
 - [x] 5.2 Test: inject two alerts differing only in `pod` label (ignored label), verify only one AgenticRun created (same dedup fingerprint)
 
 ## 6. Error Handling Tests

--- a/openspec/specs/agenticrun-building/spec.md
+++ b/openspec/specs/agenticrun-building/spec.md
@@ -3,15 +3,15 @@ Translate Alertmanager alerts into AgenticRun custom resources so the agentic op
 
 ## Requirements
 ### Requirement: Build an AgenticRun CR from a single alert
-The system SHALL convert an Alertmanager `GettableAlert` into an `AgenticRun` custom resource with deterministic naming, Kubernetes-safe metadata, and a templated request for the analysis agent. Two fingerprint labels SHALL be set: `agentic.openshift.io/alert-fingerprint` with the original AlertManager fingerprint (truncated to 8 characters) for UI lookups, and `agentic.openshift.io/alert-dedup-fingerprint` with the stable fingerprint computed from the alert's labels minus ignored labels for deduplication.
+The system SHALL convert an Alertmanager `GettableAlert` into an `AgenticRun` custom resource with deterministic naming, Kubernetes-safe metadata, and a templated request for the analysis agent. Two fingerprint labels SHALL be set: `agentic.openshift.io/alert-fingerprint` with the original AlertManager fingerprint (truncated to 8 characters) for UI lookups, and `agentic.openshift.io/alert-group-id` with the stable fingerprint computed from the alert's labels minus ignored labels for deduplication.
 
 #### Scenario: Alert with namespace label
 - **WHEN** the alert has a `namespace` label
-- **THEN** the AgenticRun name is `{alertname}-{namespace}-{startsAt_hash}`, `spec.targetNamespaces` is set to `[namespace]`, the `agentic.openshift.io/alert-fingerprint` label is set to the original AlertManager fingerprint (truncated to 8 characters), the `agentic.openshift.io/alert-dedup-fingerprint` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
+- **THEN** the AgenticRun name is `{alertname}-{namespace}-{startsAt_hash}`, `spec.targetNamespaces` is set to `[namespace]`, the `agentic.openshift.io/alert-fingerprint` label is set to the original AlertManager fingerprint (truncated to 8 characters), the `agentic.openshift.io/alert-group-id` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
 
 #### Scenario: Cluster-scoped alert (no namespace)
 - **WHEN** the alert has no `namespace` label
-- **THEN** the AgenticRun name is `{alertname}-{startsAt_hash}`, `spec.targetNamespaces` is omitted, the `agentic.openshift.io/alert-fingerprint` label is set to the original AlertManager fingerprint (truncated to 8 characters), the `agentic.openshift.io/alert-dedup-fingerprint` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
+- **THEN** the AgenticRun name is `{alertname}-{startsAt_hash}`, `spec.targetNamespaces` is omitted, the `agentic.openshift.io/alert-fingerprint` label is set to the original AlertManager fingerprint (truncated to 8 characters), the `agentic.openshift.io/alert-group-id` label is set to the stable fingerprint, and the AgenticRun is created in `openshift-lightspeed`
 
 #### Scenario: Deterministic naming produces idempotent creates
 - **WHEN** the same alert is passed to Build twice
@@ -19,7 +19,7 @@ The system SHALL convert an Alertmanager `GettableAlert` into an `AgenticRun` cu
 
 #### Scenario: Second alert for the same problem is deduplicated
 - **WHEN** two alerts differ only in ignored labels (e.g., different pod names) and an active AgenticRun already exists for the first alert
-- **THEN** the second alert produces the same `agentic.openshift.io/alert-dedup-fingerprint` label value, `hasActiveRun` matches the existing AgenticRun, and no new AgenticRun is created
+- **THEN** the second alert produces the same `agentic.openshift.io/alert-group-id` label value, `hasActiveRun` matches the existing AgenticRun, and no new AgenticRun is created
 
 ### Requirement: Sanitize alert data for Kubernetes metadata
 The system SHALL sanitize alert values to conform to Kubernetes naming and label restrictions.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -82,5 +82,5 @@ The deploy script (`hack/deploy-e2e.sh`) patches the adapter ConfigMap with test
 - **Active run deduplication**: No duplicate AgenticRun created when an active run exists for the same dedup fingerprint
 - **Ignored label deduplication**: Alerts differing only in ignored labels (`pod`, `instance`, etc.) are treated as duplicates
 - **Post-run delay**: No new AgenticRun created within `postRunDelay` after a terminal run; new run created after delay expires
-- **Fingerprint labels**: Both `alert-fingerprint` and `alert-dedup-fingerprint` are set
+- **Fingerprint labels**: Both `alert-fingerprint` and `alert-group-id` are set
 - **Error handling**: 409 AlreadyExists logged at Info level (not Error)

--- a/test/e2e/deduplication_test.go
+++ b/test/e2e/deduplication_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Deduplication", func() {
 
 			By("Waiting for multiple poll cycles and verifying no AgenticRun is created")
 			Consistently(func() (string, error) {
-				return framework.GetResourcesByLabel(context.Background(), 
+				return framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestseverityinfo",
@@ -83,7 +83,7 @@ var _ = Describe("Deduplication", func() {
 
 			By("Waiting for multiple poll cycles and verifying no AgenticRun is created")
 			Consistently(func() (string, error) {
-				return framework.GetResourcesByLabel(context.Background(), 
+				return framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestseveritynone",
@@ -128,7 +128,7 @@ var _ = Describe("Deduplication", func() {
 
 			By("Waiting for multiple poll cycles and verifying no AgenticRun is created")
 			Consistently(func() (string, error) {
-				return framework.GetResourcesByLabel(context.Background(), 
+				return framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestreceivercritical",
@@ -171,7 +171,7 @@ metadata:
   namespace: %s
   labels:
     agentic.openshift.io/source: alertmanager
-    agentic.openshift.io/alert-dedup-fingerprint: %s
+    agentic.openshift.io/alert-group-id: %s
     agentic.openshift.io/alert-name: e2etestactivededup
     agentic.openshift.io/alert-severity: warning
 spec:
@@ -192,10 +192,10 @@ spec:
 
 			By("Verifying no duplicate AgenticRun is created while the active run exists")
 			Consistently(func() int {
-				names, err := framework.GetResourcesByLabel(context.Background(), 
+				names, err := framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
-					fmt.Sprintf("agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-dedup-fingerprint=%s", testDedupFP),
+					fmt.Sprintf("agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-group-id=%s", testDedupFP),
 					"{.items[*].metadata.name}",
 				)
 				if err != nil {
@@ -249,7 +249,7 @@ spec:
 
 			By("Waiting for the adapter to create an AgenticRun")
 			Eventually(func() (string, error) {
-				return framework.GetResourcesByLabel(context.Background(), 
+				return framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestignoredlabels",
@@ -263,7 +263,7 @@ spec:
 
 			By("Verifying no additional AgenticRun is created")
 			Consistently(func() int {
-				names, err := framework.GetResourcesByLabel(context.Background(), 
+				names, err := framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestignoredlabels",
@@ -320,7 +320,7 @@ metadata:
   namespace: %s
   labels:
     agentic.openshift.io/source: alertmanager
-    agentic.openshift.io/alert-dedup-fingerprint: %s
+    agentic.openshift.io/alert-group-id: %s
     agentic.openshift.io/alert-name: e2etestpostrundelay
     agentic.openshift.io/alert-severity: warning
 spec:
@@ -347,7 +347,7 @@ spec:
 
 			By("Verifying no new AgenticRun is created within postRunDelay")
 			Consistently(func() int {
-				names, err := framework.GetResourcesByLabel(context.Background(), 
+				names, err := framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestpostrundelay",
@@ -404,7 +404,7 @@ metadata:
   namespace: %s
   labels:
     agentic.openshift.io/source: alertmanager
-    agentic.openshift.io/alert-dedup-fingerprint: %s
+    agentic.openshift.io/alert-group-id: %s
     agentic.openshift.io/alert-name: e2etestpostrunexpired
     agentic.openshift.io/alert-severity: warning
 spec:
@@ -431,7 +431,7 @@ spec:
 
 			By("Waiting for the adapter to create a new AgenticRun")
 			Eventually(func() int {
-				names, err := framework.GetResourcesByLabel(context.Background(), 
+				names, err := framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestpostrunexpired",
@@ -497,7 +497,7 @@ metadata:
     agentic.openshift.io/source: alertmanager
     agentic.openshift.io/alert-name: e2etest409handling
     agentic.openshift.io/alert-severity: warning
-    agentic.openshift.io/alert-dedup-fingerprint: %s
+    agentic.openshift.io/alert-group-id: %s
 spec:
   request: "E2E test 409 handling"
   analysis:

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Reconciliation", func() {
 
 			By("Waiting for the adapter to create an AgenticRun")
 			Eventually(func() (string, error) {
-				return framework.GetResourcesByLabel(context.Background(), 
+				return framework.GetResourcesByLabel(context.Background(),
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestreconciliation",
@@ -71,7 +71,7 @@ var _ = Describe("Reconciliation", func() {
 				"expected an AgenticRun for the injected alert")
 		})
 
-		It("should set alert-fingerprint and alert-dedup-fingerprint labels", func() {
+		It("should set alert-fingerprint and alert-group-id labels", func() {
 			ignoredLabels := []string{"pod", "instance", "endpoint", "uid"}
 			expectedDedupFP := agenticrun.StableFingerprint(alertLabels, ignoredLabels)
 
@@ -85,7 +85,7 @@ var _ = Describe("Reconciliation", func() {
 					agenticRunAPIResource,
 					cfg.Namespace,
 					"agentic.openshift.io/source=alertmanager,agentic.openshift.io/alert-name=e2etestreconciliation",
-					"{range .items[*]}{.metadata.labels.agentic\\.openshift\\.io/alert-fingerprint},{.metadata.labels.agentic\\.openshift\\.io/alert-dedup-fingerprint}{\"\\n\"}{end}",
+					"{range .items[*]}{.metadata.labels.agentic\\.openshift\\.io/alert-fingerprint},{.metadata.labels.agentic\\.openshift\\.io/alert-group-id}{\"\\n\"}{end}",
 				)
 				if err != nil {
 					return false
@@ -102,14 +102,14 @@ var _ = Describe("Reconciliation", func() {
 					alertFP := parts[0]
 					dedupFP := parts[1]
 					// alert-fingerprint must be present and non-empty (AlertManager-assigned)
-					// alert-dedup-fingerprint must match the expected computed value
+					// alert-group-id must match the expected computed value
 					if alertFP != "" && dedupFP == expectedDedupFP {
 						return true
 					}
 				}
 				return false
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue(),
-				fmt.Sprintf("AgenticRun should have alert-fingerprint set and alert-dedup-fingerprint=%s", expectedDedupFP))
+				fmt.Sprintf("AgenticRun should have alert-fingerprint set and alert-group-id=%s", expectedDedupFP))
 		})
 	})
 })


### PR DESCRIPTION
Renames original `alert-dedup-fingerprint` label to `alert-group-id` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the alert deduplication label to `alert-group-id` across architecture and usage documentation.
* **Updates**
  * AgenticRun resources now use `agentic.openshift.io/alert-group-id` for stable alert grouping.
  * Existing alert fingerprint and deduplication behavior remain unchanged.
* **Tests**
  * Updated end-to-end scenarios and validation to use the new label name across alert creation, filtering, reconciliation, and duplicate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->