### PR TITLE
OBSINTA-1650: handle EmergencyStopped AgenticRuns

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -159,6 +159,10 @@ func (a *Adapter) reconcile(ctx context.Context) {
 			continue
 		}
 
+		if hasEmergencyStoppedNameConflict(p.Name, stableFP, runs) {
+			p.Name = agenticrun.NextAvailableName(p.Name, runNames(runs))
+		}
+
 		wasCreated, err := a.arClient.CreateAgenticRun(ctx, p)
 		if err != nil {
 			a.logger.Error("failed to create run",
@@ -230,6 +234,29 @@ func hasActiveRun(stableFingerprint string, runs []agenticv1alpha1.AgenticRun) b
 	return false
 }
 
+// hasEmergencyStoppedNameConflict reports whether name belongs to a matching
+// EmergencyStopped AgenticRun.
+func hasEmergencyStoppedNameConflict(name, stableFingerprint string, runs []agenticv1alpha1.AgenticRun) bool {
+	for i := range runs {
+		if runs[i].Name != name || runs[i].Labels[agenticrun.LabelDedupFingerprint] != stableFingerprint {
+			continue
+		}
+		if agenticv1alpha1.DerivePhase(runs[i].Status.Conditions) == agenticv1alpha1.AgenticRunPhaseEmergencyStopped {
+			return true
+		}
+	}
+	return false
+}
+
+// runNames returns the names of the supplied AgenticRuns.
+func runNames(runs []agenticv1alpha1.AgenticRun) []string {
+	names := make([]string, 0, len(runs))
+	for i := range runs {
+		names = append(names, runs[i].Name)
+	}
+	return names
+}
+
 func tooRecent(stableFingerprint string, runs []agenticv1alpha1.AgenticRun, now time.Time, window time.Duration) bool {
 	for i := range runs {
 		if runs[i].Labels[agenticrun.LabelDedupFingerprint] != stableFingerprint {
@@ -258,6 +285,8 @@ func terminalTime(p *agenticv1alpha1.AgenticRun) *time.Time {
 		condType = agenticv1alpha1.AgenticRunConditionDenied
 	case agenticv1alpha1.AgenticRunPhaseEscalated:
 		condType = agenticv1alpha1.AgenticRunConditionEscalated
+	case agenticv1alpha1.AgenticRunPhaseEmergencyStopped:
+		condType = agenticv1alpha1.AgenticRunConditionEmergencyStopped
 	default:
 		return nil
 	}
@@ -289,7 +318,8 @@ func isTerminal(phase agenticv1alpha1.AgenticRunPhase) bool {
 	case agenticv1alpha1.AgenticRunPhaseCompleted,
 		agenticv1alpha1.AgenticRunPhaseFailed,
 		agenticv1alpha1.AgenticRunPhaseDenied,
-		agenticv1alpha1.AgenticRunPhaseEscalated:
+		agenticv1alpha1.AgenticRunPhaseEscalated,
+		agenticv1alpha1.AgenticRunPhaseEmergencyStopped:
 		return true
 	}
 	return false

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,9 +94,13 @@ func makeAlertWithSeverity(name, fingerprint string, startsAt time.Time, severit
 }
 
 func makeRun(fingerprint string, conditions []metav1.Condition) agenticv1alpha1.AgenticRun {
+	return makeRunWithName("test-"+fingerprint, fingerprint, conditions)
+}
+
+func makeRunWithName(name, fingerprint string, conditions []metav1.Condition) agenticv1alpha1.AgenticRun {
 	return agenticv1alpha1.AgenticRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-" + fingerprint,
+			Name:      name,
 			Namespace: "openshift-lightspeed",
 			Labels: map[string]string{
 				agenticrun.LabelDedupFingerprint: fingerprint,
@@ -116,6 +121,11 @@ func TestReconcile(t *testing.T) {
 	pastPostDelay := now.Add(-2 * time.Hour)
 
 	highCPUFP := stableFP(models.LabelSet{"alertname": "HighCPU", "severity": "warning"})
+	emergencyStoppedAlert := makeAlert("HighCPU", "abcdef1234567890", oldEnough)
+	emergencyStoppedBase, err := agenticrun.Build(emergencyStoppedAlert, config.ToolsConfig{}, config.AgentConfig{}, config.DefaultIgnoredLabels, agenticrun.RunNamespace)
+	if err != nil {
+		t.Fatalf("build base run for EmergencyStopped test: %v", err)
+	}
 
 	tests := []struct {
 		name            string
@@ -127,6 +137,7 @@ func TestReconcile(t *testing.T) {
 		runsErr         error
 		createErr       error
 		wasCreated      *bool
+		wantNameSuffix  string
 	}{
 		{
 			name:            "new alert creates run",
@@ -225,6 +236,36 @@ func TestReconcile(t *testing.T) {
 			wantCreated: 0,
 		},
 		{
+			name:   "emergencystopped run within post-run delay skipped",
+			alerts: models.GettableAlerts{makeAlert("HighCPU", "abcdef1234567890", oldEnough)},
+			runs: []agenticv1alpha1.AgenticRun{
+				makeRun(highCPUFP, []metav1.Condition{
+					{
+						Type:               agenticv1alpha1.AgenticRunConditionEmergencyStopped,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(withinPostDelay),
+					},
+				}),
+			},
+			wantCreated: 0,
+		},
+		{
+			name:   "emergencystopped run outside post-run delay creates replacement run",
+			alerts: models.GettableAlerts{emergencyStoppedAlert},
+			runs: []agenticv1alpha1.AgenticRun{
+				makeRunWithName(emergencyStoppedBase.Name, highCPUFP, []metav1.Condition{
+					{
+						Type:               agenticv1alpha1.AgenticRunConditionEmergencyStopped,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(pastPostDelay),
+					},
+				}),
+			},
+			wantCreated:     1,
+			wantCreateCalls: 1,
+			wantNameSuffix:  "-retry-1",
+		},
+		{
 			name:        "alertmanager error skips cycle",
 			alertsErr:   errors.New("connection refused"),
 			wantCreated: 0,
@@ -301,6 +342,14 @@ func TestReconcile(t *testing.T) {
 			}
 			if rc.createCalls != tt.wantCreateCalls {
 				t.Errorf("CreateAgenticRun called %d times, want %d", rc.createCalls, tt.wantCreateCalls)
+			}
+			if tt.wantNameSuffix != "" {
+				if len(rc.created) != 1 {
+					t.Fatalf("created %d runs, want 1", len(rc.created))
+				}
+				if !strings.HasSuffix(rc.created[0].Name, tt.wantNameSuffix) {
+					t.Errorf("created run name = %q, want suffix %q", rc.created[0].Name, tt.wantNameSuffix)
+				}
 			}
 		})
 	}

--- a/internal/agenticrun/build.go
+++ b/internal/agenticrun/build.go
@@ -275,6 +275,27 @@ func resolveAgent(perStep, global string) string {
 	return defaultAgent
 }
 
+// NextAvailableName returns baseName when unused, otherwise returns the first
+// available deterministic retry name using -retry-N suffixes.
+func NextAvailableName(baseName string, existingNames []string) string {
+	existing := make(map[string]struct{}, len(existingNames))
+	for _, name := range existingNames {
+		existing[name] = struct{}{}
+	}
+
+	if _, ok := existing[baseName]; !ok {
+		return baseName
+	}
+
+	for i := 1; ; i++ {
+		suffix := fmt.Sprintf("-retry-%d", i)
+		candidate := truncateDNS(baseName, maxLabelValueLen-len(suffix)) + suffix
+		if _, ok := existing[candidate]; !ok {
+			return candidate
+		}
+	}
+}
+
 func truncateDNS(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s

--- a/internal/agenticrun/build_test.go
+++ b/internal/agenticrun/build_test.go
@@ -407,6 +407,36 @@ func TestBuildRequestWithoutRunbook(t *testing.T) {
 	}
 }
 
+func TestNextAvailableName(t *testing.T) {
+	t.Run("returns base name when unused", func(t *testing.T) {
+		base := "testalert-ns-895c8977"
+		got := NextAvailableName(base, []string{"other-run"})
+		if got != base {
+			t.Errorf("NextAvailableName() = %q, want %q", got, base)
+		}
+	})
+
+	t.Run("returns next retry suffix", func(t *testing.T) {
+		base := "testalert-ns-895c8977"
+		got := NextAvailableName(base, []string{base, base + "-retry-1"})
+		want := base + "-retry-2"
+		if got != want {
+			t.Errorf("NextAvailableName() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("truncates base to preserve name length", func(t *testing.T) {
+		base := strings.Repeat("a", maxLabelValueLen)
+		got := NextAvailableName(base, []string{base})
+		if len(got) > maxLabelValueLen {
+			t.Fatalf("NextAvailableName() length = %d, want <= %d", len(got), maxLabelValueLen)
+		}
+		if !strings.HasSuffix(got, "-retry-1") {
+			t.Errorf("NextAvailableName() = %q, want retry suffix", got)
+		}
+	})
+}
+
 func TestBuildName(t *testing.T) {
 	testTime := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
 	hash := startsAtHash(testTime)
@@ -627,8 +657,8 @@ func TestBuildRequestSanitizesAdversarialContent(t *testing.T) {
 			wantAbsent:  []string{"real desc```"},
 		},
 		{
-			name:      "adversarial alertname is sanitized",
-			alertName: "FakeAlert\x00\x1bRealPayload",
+			name:        "adversarial alertname is sanitized",
+			alertName:   "FakeAlert\x00\x1bRealPayload",
 			wantPresent: []string{"FakeAlertRealPayload"},
 		},
 		{

--- a/openspec/specs/agenticrun-building/spec.md
+++ b/openspec/specs/agenticrun-building/spec.md
@@ -21,6 +21,21 @@ The system SHALL convert an Alertmanager `GettableAlert` into an `AgenticRun` cu
 - **WHEN** two alerts differ only in ignored labels (e.g., different pod names) and an active AgenticRun already exists for the first alert
 - **THEN** the second alert produces the same `agentic.openshift.io/alert-group-id` label value, `hasActiveRun` matches the existing AgenticRun, and no new AgenticRun is created
 
+### Requirement: Build replacement AgenticRuns after EmergencyStopped
+The system SHALL support creating a replacement AgenticRun for a still-firing alert when the original alert-derived AgenticRun name already exists for an EmergencyStopped run and the alert is eligible for creation.
+
+#### Scenario: Replacement AgenticRun after EmergencyStopped
+- **WHEN** an alert is still firing, the original deterministic AgenticRun name already exists for that alert instance, and the existing matching run is EmergencyStopped outside the configured post-run delay
+- **THEN** the system creates a replacement AgenticRun using the next deterministic retry name
+
+#### Scenario: Retry name preserves Kubernetes constraints
+- **WHEN** a replacement AgenticRun name requires a retry suffix
+- **THEN** the final name remains within the existing Kubernetes name length limit
+
+#### Scenario: Deterministic retry naming
+- **WHEN** the same set of existing AgenticRuns is evaluated for the same alert instance
+- **THEN** the same next retry name is selected
+
 ### Requirement: Sanitize alert data for Kubernetes metadata
 The system SHALL sanitize alert values to conform to Kubernetes naming and label restrictions.
 

--- a/openspec/specs/configmap-config/spec.md
+++ b/openspec/specs/configmap-config/spec.md
@@ -73,6 +73,10 @@ The system SHALL read the `POD_NAMESPACE` environment variable to determine the 
 ### Requirement: Restructure config YAML with filtering and deduplication sections
 The system SHALL support a structured config YAML where `allowedReceivers` is nested under a `filtering` section and `ignoredLabels` is nested under a `deduplication` section. Top-level `allowedReceivers` SHALL continue to be accepted for backward compatibility.
 
+#### Scenario: Structured configuration is provided
+- **WHEN** the ConfigMap contains `filtering.allowedReceivers` and `deduplication.ignoredLabels`
+- **THEN** the system loads both values from their respective structured sections
+
 ### Requirement: Support ignored labels configuration
 The system SHALL support a `deduplication.ignoredLabels` field in the ConfigMap YAML that specifies which alert labels to exclude when computing the stable fingerprint. When the field is absent, the system SHALL use the default list: `[pod, instance, endpoint, uid]`. When the field is explicitly set, the specified list fully replaces the default (no merging).
 

--- a/openspec/specs/poll-loop/spec.md
+++ b/openspec/specs/poll-loop/spec.md
@@ -41,18 +41,22 @@ The system SHALL not create an AgenticRun for an alert that has been firing for 
 - **THEN** the alert passes the pre-run delay check
 
 ### Requirement: Skip alerts with active AgenticRuns
-The system SHALL not create an AgenticRun for an alert that already has an active (non-terminal) AgenticRun, identified by matching the alert fingerprint label.
+The system SHALL not create an AgenticRun for an alert that already has an active (non-terminal) AgenticRun, identified by matching the alert fingerprint label. `EmergencyStopped` SHALL be treated as terminal, not active.
 
 #### Scenario: Active AgenticRun exists for alert
 - **WHEN** an AgenticRun with matching fingerprint label exists and its phase is Pending, Analyzing, Proposed, Executing, Verifying, or Escalating
 - **THEN** the alert is skipped and logged at Debug level
+
+#### Scenario: EmergencyStopped AgenticRun exists for alert
+- **WHEN** the only AgenticRun with matching fingerprint label is in phase EmergencyStopped
+- **THEN** the alert passes the active-run check
 
 #### Scenario: No AgenticRun exists for alert
 - **WHEN** no AgenticRun with matching fingerprint label exists
 - **THEN** the alert passes the active-run check
 
 ### Requirement: Skip alerts within post-run delay
-The system SHALL not create an AgenticRun for an alert that has a terminal AgenticRun (Completed, Failed, Denied, Escalated) within the configured `postRunDelay` (default 1h), to avoid repeated analysis of an alert that has already been investigated. When `postRunDelay` is 0, this check is a no-op and all alerts pass.
+The system SHALL not create an AgenticRun for an alert that has a terminal AgenticRun (Completed, Failed, Denied, Escalated, EmergencyStopped) within the configured `postRunDelay` (default 1h), to avoid repeated analysis of an alert that has recently reached a terminal state. When `postRunDelay` is 0, this check is a no-op and all alerts pass.
 
 #### Scenario: postRunDelay is 0
 - **WHEN** `postRunDelay` is 0s
@@ -64,6 +68,14 @@ The system SHALL not create an AgenticRun for an alert that has a terminal Agent
 
 #### Scenario: Terminal AgenticRun outside postRunDelay
 - **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in a terminal phase and its terminal condition's `LastTransitionTime` is equal to or greater than `postRunDelay` ago
+- **THEN** the alert passes the post-run delay check
+
+#### Scenario: EmergencyStopped AgenticRun within postRunDelay
+- **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in phase EmergencyStopped and its EmergencyStopped condition's `LastTransitionTime` is less than `postRunDelay` ago
+- **THEN** the alert is skipped and logged at Debug level
+
+#### Scenario: EmergencyStopped AgenticRun outside postRunDelay
+- **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in phase EmergencyStopped and its EmergencyStopped condition's `LastTransitionTime` is equal to or greater than `postRunDelay` ago
 - **THEN** the alert passes the post-run delay check
 
 ### Requirement: Shut down gracefully on OS signals


### PR DESCRIPTION
Treat EmergencyStopped runs as terminal and apply the normal post-run delay. Create deterministic retry-named replacements after the delay when the original run still exists.


Assisted-by: OpenAI:unspecified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically creates replacement runs when an existing run was emergency-stopped and the post-run delay has elapsed.
  * Assigns deterministic retry names such as `-retry-1`, while respecting name length limits.
  * Treats emergency-stopped runs as terminal when evaluating active alerts and post-run delays.

* **Documentation**
  * Updated specifications for emergency-stopped run recovery and structured configuration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->