### PR TITLE
OBSINTA-1655: read adapter suspension from AgenticOLSConfig

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -358,6 +358,10 @@ subjects:
 | `ALERTMANAGER_URL` | `https://alertmanager-main.openshift-monitoring.svc:9094` | AlertManager API endpoint |
 | `POD_NAMESPACE` | `openshift-lightspeed` | Adapter's namespace (set via downward API in the deployment manifest) |
 
+### AgenticOLSConfig
+
+The adapter reads the cluster-scoped `AgenticOLSConfig` singleton named `cluster` at the start of each poll cycle. If `spec.suspended` is `true`, the adapter skips the current cycle before polling AlertManager or accessing AgenticRuns. If the CRD or singleton object is absent, the adapter behaves as if suspended mode is disabled.
+
 ### ConfigMap
 
 The `alerts-adapter-config` ConfigMap is mounted as a volume at `/etc/alerts-adapter/` and read once at startup from the `config.yaml` key. If the file is missing or malformed, defaults are used. The operator watches the ConfigMap and restarts the adapter pod when the config changes.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ The adapter runs as a single-replica Deployment in the `openshift-lightspeed` na
 |---|---|---|
 | `ALERTMANAGER_URL` | `https://alertmanager-main.openshift-monitoring.svc:9094` | AlertManager API endpoint |
 
+### Suspended mode
+
+The adapter checks the cluster-scoped `AgenticOLSConfig` singleton named `cluster` at the start of each poll cycle. When `spec.suspended` is `true`, the adapter skips that poll cycle before polling AlertManager or accessing `AgenticRun` resources.
+
+When the `AgenticOLSConfig` CRD or singleton object is absent, the adapter behaves as if suspended mode is disabled. If reading `AgenticOLSConfig` fails for another reason, the adapter logs the error and skips the current poll cycle; the next poll retries.
+
+Example:
+
+```yaml
+apiVersion: agentic.openshift.io/v1alpha1
+kind: AgenticOLSConfig
+metadata:
+  name: cluster
+spec:
+  suspended: true
+```
+
 ### ConfigMap
 
 Runtime-tunable parameters are read from the `alerts-adapter-config` ConfigMap in the `openshift-lightspeed` namespace (key: `config.yaml`), mounted as a volume and read once at startup. The operator restarts the adapter pod when the ConfigMap changes. If the ConfigMap is missing, defaults are used. Invalid YAML or unparseable duration values cause the adapter to fail to start.

--- a/cmd/alerts-adapter/main.go
+++ b/cmd/alerts-adapter/main.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/lightspeed-agentic-alerts-adapter/internal/adapter"
+	"github.com/openshift/lightspeed-agentic-alerts-adapter/internal/agenticolsconfig"
 	"github.com/openshift/lightspeed-agentic-alerts-adapter/internal/agenticrun"
 	"github.com/openshift/lightspeed-agentic-alerts-adapter/internal/alertmanager"
 	"github.com/openshift/lightspeed-agentic-alerts-adapter/internal/config"
@@ -54,8 +55,9 @@ func main() {
 	}
 
 	runClient := agenticrun.NewClient(k8sClient, namespace, logger)
+	suspensionClient := agenticolsconfig.NewClient(k8sClient)
 
-	a := adapter.New(amClient, runClient, cfg, namespace, logger)
+	a := adapter.New(amClient, runClient, suspensionClient, cfg, namespace, logger)
 	if err := a.Run(ctx); err != nil {
 		logger.Error("fatal error", "error", err)
 		os.Exit(1)

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -28,26 +28,33 @@ type AgenticRunClient interface {
 	CreateAgenticRun(ctx context.Context, p *agenticv1alpha1.AgenticRun) (bool, error)
 }
 
+// SuspensionSource retrieves the current adapter suspension state.
+type SuspensionSource interface {
+	Suspended(ctx context.Context) (bool, error)
+}
+
 // Adapter polls AlertManager for firing alerts and creates AgenticRun CRs,
 // applying stateless deduplication (pre-run delay, active-run check,
 // and post-run delay) on each cycle.
 type Adapter struct {
-	alerts    AlertSource
-	arClient  AgenticRunClient
-	cfg       config.Config
-	namespace string
-	logger    *slog.Logger
+	alerts     AlertSource
+	arClient   AgenticRunClient
+	suspension SuspensionSource
+	cfg        config.Config
+	namespace  string
+	logger     *slog.Logger
 }
 
 // New creates an Adapter with the given alert source, run client,
-// config, namespace, and logger.
-func New(alerts AlertSource, arClient AgenticRunClient, cfg config.Config, namespace string, logger *slog.Logger) *Adapter {
+// suspension source, config, namespace, and logger.
+func New(alerts AlertSource, arClient AgenticRunClient, suspension SuspensionSource, cfg config.Config, namespace string, logger *slog.Logger) *Adapter {
 	return &Adapter{
-		alerts:    alerts,
-		arClient:  arClient,
-		cfg:       cfg,
-		namespace: namespace,
-		logger:    logger,
+		alerts:     alerts,
+		arClient:   arClient,
+		suspension: suspension,
+		cfg:        cfg,
+		namespace:  namespace,
+		logger:     logger,
 	}
 }
 
@@ -78,6 +85,16 @@ func (a *Adapter) Run(ctx context.Context) error {
 
 func (a *Adapter) reconcile(ctx context.Context) {
 	a.logger.Debug("poll cycle start")
+
+	suspended, err := a.suspension.Suspended(ctx)
+	if err != nil {
+		a.logger.Error("failed to read AgenticOLSConfig suspension state", "error", err)
+		return
+	}
+	if suspended {
+		a.logger.Info("AgenticOLSConfig suspension is enabled; skipping poll cycle")
+		return
+	}
 
 	alerts, err := a.alerts.GetAlerts(ctx)
 	if err != nil {

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -19,11 +19,13 @@ import (
 )
 
 type fakeAlertSource struct {
-	alerts models.GettableAlerts
-	err    error
+	alerts   models.GettableAlerts
+	err      error
+	getCalls int
 }
 
 func (f *fakeAlertSource) GetAlerts(_ context.Context) (models.GettableAlerts, error) {
+	f.getCalls++
 	return f.alerts, f.err
 }
 
@@ -32,11 +34,13 @@ type fakeRunClient struct {
 	listErr     error
 	createErr   error
 	created     []*agenticv1alpha1.AgenticRun
+	listCalls   int
 	createCalls int
 	wasCreated  *bool
 }
 
 func (f *fakeRunClient) ListAgenticRuns(_ context.Context) ([]agenticv1alpha1.AgenticRun, error) {
+	f.listCalls++
 	return f.runs, f.listErr
 }
 
@@ -50,6 +54,17 @@ func (f *fakeRunClient) CreateAgenticRun(_ context.Context, p *agenticv1alpha1.A
 	}
 	f.created = append(f.created, p)
 	return true, nil
+}
+
+type fakeSuspensionSource struct {
+	suspended bool
+	err       error
+	calls     int
+}
+
+func (f *fakeSuspensionSource) Suspended(_ context.Context) (bool, error) {
+	f.calls++
+	return f.suspended, f.err
 }
 
 func quietLogger() *slog.Logger {
@@ -328,11 +343,12 @@ func TestReconcile(t *testing.T) {
 			rc := &fakeRunClient{runs: tt.runs, listErr: tt.runsErr, createErr: tt.createErr, wasCreated: tt.wasCreated}
 
 			a := &Adapter{
-				alerts:    as,
-				arClient:  rc,
-				cfg:       defaultTestConfig(),
-				namespace: agenticrun.RunNamespace,
-				logger:    quietLogger(),
+				alerts:     as,
+				arClient:   rc,
+				suspension: &fakeSuspensionSource{},
+				cfg:        defaultTestConfig(),
+				namespace:  agenticrun.RunNamespace,
+				logger:     quietLogger(),
 			}
 
 			a.reconcile(context.Background())
@@ -462,11 +478,12 @@ func TestReconcileSkipsSeverity(t *testing.T) {
 			rc := &fakeRunClient{}
 
 			a := &Adapter{
-				alerts:    as,
-				arClient:  rc,
-				cfg:       defaultTestConfig(),
-				namespace: agenticrun.RunNamespace,
-				logger:    quietLogger(),
+				alerts:     as,
+				arClient:   rc,
+				suspension: &fakeSuspensionSource{},
+				cfg:        defaultTestConfig(),
+				namespace:  agenticrun.RunNamespace,
+				logger:     quietLogger(),
 			}
 
 			a.reconcile(context.Background())
@@ -493,11 +510,12 @@ func TestReconcileWithTools(t *testing.T) {
 		}
 
 		a := &Adapter{
-			alerts:    as,
-			arClient:  rc,
-			cfg:       cfg,
-			namespace: agenticrun.RunNamespace,
-			logger:    quietLogger(),
+			alerts:     as,
+			arClient:   rc,
+			suspension: &fakeSuspensionSource{},
+			cfg:        cfg,
+			namespace:  agenticrun.RunNamespace,
+			logger:     quietLogger(),
 		}
 
 		a.reconcile(context.Background())
@@ -528,11 +546,12 @@ func TestReconcileWithTools(t *testing.T) {
 		}
 
 		a := &Adapter{
-			alerts:    as,
-			arClient:  rc,
-			cfg:       cfg,
-			namespace: agenticrun.RunNamespace,
-			logger:    quietLogger(),
+			alerts:     as,
+			arClient:   rc,
+			suspension: &fakeSuspensionSource{},
+			cfg:        cfg,
+			namespace:  agenticrun.RunNamespace,
+			logger:     quietLogger(),
 		}
 
 		a.reconcile(context.Background())
@@ -606,7 +625,7 @@ func TestReconcileZeroDelays(t *testing.T) {
 			cfg.PreRunDelay = tt.preRunDelay
 			cfg.PostRunDelay = tt.postRunDelay
 
-			a := &Adapter{alerts: as, arClient: rc, cfg: cfg, namespace: agenticrun.RunNamespace, logger: quietLogger()}
+			a := &Adapter{alerts: as, arClient: rc, suspension: &fakeSuspensionSource{}, cfg: cfg, namespace: agenticrun.RunNamespace, logger: quietLogger()}
 			a.reconcile(context.Background())
 
 			if rc.createCalls != 1 {
@@ -632,11 +651,12 @@ func TestReconcileDedupsWithinSameCycle(t *testing.T) {
 	rc := &fakeRunClient{}
 
 	a := &Adapter{
-		alerts:    as,
-		arClient:  rc,
-		cfg:       defaultTestConfig(),
-		namespace: agenticrun.RunNamespace,
-		logger:    quietLogger(),
+		alerts:     as,
+		arClient:   rc,
+		suspension: &fakeSuspensionSource{},
+		cfg:        defaultTestConfig(),
+		namespace:  agenticrun.RunNamespace,
+		logger:     quietLogger(),
 	}
 
 	a.reconcile(context.Background())
@@ -657,10 +677,11 @@ func TestRunExitsOnContextCancel(t *testing.T) {
 	cfg.PollInterval = time.Hour
 
 	a := &Adapter{
-		alerts:   as,
-		arClient: rc,
-		cfg:      cfg,
-		logger:   quietLogger(),
+		alerts:     as,
+		arClient:   rc,
+		suspension: &fakeSuspensionSource{},
+		cfg:        cfg,
+		logger:     quietLogger(),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -676,5 +697,56 @@ func TestRunExitsOnContextCancel(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not exit after context cancellation")
+	}
+}
+
+func TestReconcileSkipsCycleForSuspensionState(t *testing.T) {
+	tests := []struct {
+		name      string
+		suspended bool
+		err       error
+	}{
+		{
+			name:      "suspended skips cycle",
+			suspended: true,
+		},
+		{
+			name: "suspension read error skips cycle",
+			err:  errors.New("api server unavailable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as := &fakeAlertSource{alerts: models.GettableAlerts{
+				makeAlert("HighCPU", "abcdef1234567890", time.Now().Add(-10*time.Minute)),
+			}}
+			rc := &fakeRunClient{}
+			ss := &fakeSuspensionSource{suspended: tt.suspended, err: tt.err}
+
+			a := &Adapter{
+				alerts:     as,
+				arClient:   rc,
+				suspension: ss,
+				cfg:        defaultTestConfig(),
+				namespace:  agenticrun.RunNamespace,
+				logger:     quietLogger(),
+			}
+
+			a.reconcile(context.Background())
+
+			if ss.calls != 1 {
+				t.Errorf("Suspended called %d times, want 1", ss.calls)
+			}
+			if as.getCalls != 0 {
+				t.Errorf("GetAlerts called %d times, want 0", as.getCalls)
+			}
+			if rc.listCalls != 0 {
+				t.Errorf("ListAgenticRuns called %d times, want 0", rc.listCalls)
+			}
+			if rc.createCalls != 0 {
+				t.Errorf("CreateAgenticRun called %d times, want 0", rc.createCalls)
+			}
+		})
 	}
 }

--- a/internal/agenticolsconfig/client.go
+++ b/internal/agenticolsconfig/client.go
@@ -1,0 +1,40 @@
+package agenticolsconfig
+
+import (
+	"context"
+	"fmt"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigName is the name of the cluster-scoped AgenticOLSConfig singleton.
+const ConfigName = "cluster"
+
+// Client reads AgenticOLSConfig resources from the cluster.
+type Client struct {
+	client.Client
+}
+
+// NewClient creates a Client that wraps the given controller-runtime client.
+func NewClient(c client.Client) *Client {
+	return &Client{Client: c}
+}
+
+// Suspended returns true when AgenticOLSConfig.spec.suspended is true.
+// Missing AgenticOLSConfig CRD or missing singleton object means not suspended.
+func (c *Client) Suspended(ctx context.Context) (bool, error) {
+	var cfg agenticv1alpha1.AgenticOLSConfig
+
+	if err := c.Get(ctx, types.NamespacedName{Name: ConfigName}, &cfg); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("agenticolsconfig: getting %s: %w", ConfigName, err)
+	}
+
+	return cfg.Spec.Suspended, nil
+}

--- a/internal/agenticolsconfig/client_test.go
+++ b/internal/agenticolsconfig/client_test.go
@@ -1,0 +1,63 @@
+package agenticolsconfig
+
+import (
+	"context"
+	"testing"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSuspended(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *agenticv1alpha1.AgenticOLSConfig
+		want bool
+	}{
+		{
+			name: "suspended",
+			obj: &agenticv1alpha1.AgenticOLSConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: ConfigName},
+				Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: true},
+			},
+			want: true,
+		},
+		{
+			name: "not suspended",
+			obj: &agenticv1alpha1.AgenticOLSConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: ConfigName},
+				Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: false},
+			},
+			want: false,
+		},
+		{
+			name: "missing config means not suspended",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := agenticv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatalf("AddToScheme() error = %v", err)
+			}
+
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.obj != nil {
+				builder.WithObjects(tt.obj)
+			}
+
+			c := NewClient(builder.Build())
+			got, err := c.Suspended(context.Background())
+			if err != nil {
+				t.Fatalf("Suspended() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Suspended() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -37,3 +37,27 @@ subjects:
   - kind: ServiceAccount
     name: lightspeed-agentic-alerts-adapter
     namespace: openshift-lightspeed
+---
+# AgenticOLSConfig: read cluster-wide suspension state.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lightspeed-agentic-alerts-adapter-agenticolsconfig
+rules:
+  - apiGroups: ["agentic.openshift.io"]
+    resources: ["agenticolsconfigs"]
+    resourceNames: ["cluster"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lightspeed-agentic-alerts-adapter-agenticolsconfig
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lightspeed-agentic-alerts-adapter-agenticolsconfig
+subjects:
+  - kind: ServiceAccount
+    name: lightspeed-agentic-alerts-adapter
+    namespace: openshift-lightspeed

--- a/openspec/changes/archive/2026-09-04-add-suspended-mode/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-add-suspended-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-04-add-suspended-mode/design.md
+++ b/openspec/changes/archive/2026-09-04-add-suspended-mode/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The adapter starts by loading file-based configuration, constructing AlertManager and Kubernetes clients, then running `adapter.Run(ctx)`. `Run` immediately performs one reconcile before starting its ticker. Each reconcile can therefore check the current cluster-wide suspension state before accessing AlertManager or `AgenticRun` resources.
+
+`AgenticOLSConfig` is a cluster-scoped singleton named `cluster`. Its `spec.suspended` flag is the existing cluster-wide control for agentic operations. The CR is optional; when it or its CRD is absent, the operator API defines normal behavior as unsuspended.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Read `AgenticOLSConfig.spec.suspended` at the start of every reconcile cycle.
+- Skip AlertManager retrieval and `AgenticRun` listing or creation when suspension is enabled.
+- Treat a missing `AgenticOLSConfig` CRD or singleton object as unsuspended.
+- Skip and retry the cycle when the suspension state cannot otherwise be read.
+- Keep the existing poll-loop architecture without a controller-runtime manager or watch.
+
+**Non-Goals:**
+- Suspending or cancelling already-created `AgenticRun` resources.
+- Changing receiver filtering, deduplication, or AgenticRun build semantics.
+
+## Decisions
+
+### 1. Check AgenticOLSConfig during each reconcile
+
+The adapter defines a `SuspensionSource` interface and calls `Suspended(ctx)` as the first operation in `reconcile`. If it returns true, the adapter logs that `AgenticOLSConfig` suspension is enabled and returns before calling AlertManager or the `AgenticRun` client.
+
+Rationale: the adapter already polls AlertManager and lists `AgenticRun` resources per cycle. A per-cycle Kubernetes read gives dynamic suspension changes effect on the next poll without adding watch, cache, manager, or shared-state lifecycle handling.
+
+Alternative considered: controller-runtime watch. Rejected because this polling adapter does not otherwise run a manager or cache; adding a watch would require extra lifecycle and optional-CRD handling for little benefit.
+
+### 2. Retrieve the cluster-scoped singleton by name
+
+`internal/agenticolsconfig.Client` uses the existing controller-runtime client to get `AgenticOLSConfig` with the cluster-scoped name `cluster`. It returns `cfg.Spec.Suspended` when found.
+
+`NotFound` and `NoMatch` errors return `false, nil`, preserving normal operation in clusters without the optional CR or CRD. Other errors are returned to the adapter, which logs them and skips the current cycle.
+
+Rationale: a named `Get` needs only `get` authorization and follows the singleton contract. Treating only absence as unsuspended prevents remediation when the configured control state cannot be read.
+
+### 3. Grant minimal cluster RBAC
+
+The adapter service account receives a `ClusterRole` and `ClusterRoleBinding` granting `get` for `agentic.openshift.io/agenticolsconfigs`.
+
+Rationale: `AgenticOLSConfig` is cluster-scoped, so a namespace-scoped Role cannot grant access. The adapter uses a known singleton name and does not need `list` or `watch`.
+
+## Risks / Trade-offs
+
+- **[Trade-off] Suspension changes take effect on the next poll interval** → The adapter checks the CR once per reconcile; this avoids adding a watch to the polling architecture.
+- **[Risk] Suspension-state read errors prevent processing for a cycle** → Mitigation: log the error and retry at the next poll. This avoids creating remediation runs while the cluster-wide control state is unknown.
+- **[Risk] Suspended pods remain healthy while doing no work** → Mitigation: log that `AgenticOLSConfig` suspension caused the cycle to be skipped.
+
+## Migration Plan
+
+No data migration is required. Clusters without an `AgenticOLSConfig` CRD or singleton retain normal behavior. To suspend the adapter, set `spec.suspended: true` on `AgenticOLSConfig/cluster`; set it back to `false` to allow subsequent poll cycles to create new `AgenticRun` resources.

--- a/openspec/changes/archive/2026-09-04-add-suspended-mode/proposal.md
+++ b/openspec/changes/archive/2026-09-04-add-suspended-mode/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Operators need a way to temporarily disable the alerts adapter without deleting the Deployment, changing AlertManager routing, or risking new automated remediation activity. The cluster-scoped `AgenticOLSConfig` singleton provides the existing operational kill switch.
+
+## What Changes
+
+- Read the `AgenticOLSConfig` singleton named `cluster` at the start of each reconcile cycle.
+- When `spec.suspended` is true, skip the cycle before polling AlertManager or listing or creating `AgenticRun` resources.
+- Treat an absent `AgenticOLSConfig` CRD or singleton object as unsuspended.
+- Log and skip the current cycle when the suspension state cannot otherwise be read; retry on the next poll.
+- Grant the adapter service account cluster-scoped `get` permission for `AgenticOLSConfig`.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `poll-loop`: Add a suspended mode exception to the normal reconcile loop so no polling or AgenticRun creation occurs while suspended.
+- `alert-retrieval`: Clarify that AlertManager retrieval is not attempted during a suspended reconcile cycle.
+
+## Impact
+
+- `cmd/alerts-adapter/main.go` — construct and wire an `AgenticOLSConfig` client into the adapter.
+- `internal/adapter/` — check suspension before AlertManager or AgenticRun access.
+- `internal/agenticolsconfig/` — retrieve the cluster-scoped singleton and handle its optional presence.
+- `manifests/rbac.yaml` — allow reading the cluster-scoped `AgenticOLSConfig`.
+- Documentation and tests for cycle-level suspension behavior.

--- a/openspec/changes/archive/2026-09-04-add-suspended-mode/specs/alert-retrieval/spec.md
+++ b/openspec/changes/archive/2026-09-04-add-suspended-mode/specs/alert-retrieval/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Log retrieved alerts during initial reconcile
+The system SHALL fetch alerts during the initial reconcile cycle and log a summary of the results using structured logging when suspended mode is disabled. When suspended mode is enabled through `AgenticOLSConfig.spec.suspended`, the system SHALL skip alert retrieval for that reconcile cycle and SHALL log that the adapter is suspended.
+
+#### Scenario: Alerts fetched and logged
+- **WHEN** suspended mode is disabled and the initial reconcile cycle successfully retrieves alerts
+- **THEN** the system logs the number of alerts retrieved and key details for each alert
+
+#### Scenario: Alert retrieval fails during initial reconcile
+- **WHEN** suspended mode is disabled and alert retrieval fails during the initial reconcile cycle
+- **THEN** the system logs the error and the next poll retries
+
+#### Scenario: Alert retrieval skipped while suspended
+- **WHEN** `AgenticOLSConfig.spec.suspended` is true and a reconcile cycle begins
+- **THEN** the system does not fetch alerts and logs that the adapter is suspended

--- a/openspec/changes/archive/2026-09-04-add-suspended-mode/specs/poll-loop/spec.md
+++ b/openspec/changes/archive/2026-09-04-add-suspended-mode/specs/poll-loop/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Poll AlertManager on a fixed interval
+The system SHALL read operational parameters (`pollInterval`, `preRunDelay`, `postRunDelay`) from the `ConfigSource` at the start of each reconcile cycle and use them for that cycle's filtering and deduplication rules. The default poll interval is 30 seconds. When the loaded `pollInterval` differs from the current ticker interval, the system SHALL reset the ticker to the new interval. The filter order SHALL be: receiver allowlist -> pre-run delay -> active AgenticRun -> post-run delay. At the start of each reconcile cycle, the system SHALL read the cluster-scoped `AgenticOLSConfig` singleton named `cluster`; when `spec.suspended` is true, the system SHALL skip that reconcile cycle before polling AlertManager, listing existing AgenticRuns, or creating AgenticRuns. When the `AgenticOLSConfig` CRD or singleton object is absent, the system SHALL behave as if suspended mode is disabled.
+
+#### Scenario: Normal poll cycle
+- **WHEN** suspended mode is disabled and the poll interval elapses
+- **THEN** the system fetches alerts from AlertManager, lists existing AgenticRuns, applies receiver filtering then dedup rules, and creates AgenticRuns for qualifying alerts
+
+#### Scenario: Configuration loaded each cycle
+- **WHEN** suspended mode is disabled and a reconcile cycle begins
+- **THEN** the system calls `ConfigSource.Load()` and uses the returned values for that cycle's pre-run delay check and post-run delay check
+
+#### Scenario: Poll interval changes between cycles
+- **WHEN** suspended mode is disabled and the `pollInterval` value from `ConfigSource.Load()` differs from the current ticker interval
+- **THEN** the system resets the ticker to the new interval and logs the change
+
+#### Scenario: Suspended mode enabled
+- **WHEN** the `AgenticOLSConfig` singleton named `cluster` exists with `spec.suspended` set to true and a reconcile cycle begins
+- **THEN** the system logs that the adapter is suspended and skips the reconcile cycle
+
+#### Scenario: AgenticOLSConfig absent
+- **WHEN** the `AgenticOLSConfig` CRD or singleton object named `cluster` is absent and a reconcile cycle begins
+- **THEN** the system treats suspended mode as disabled and continues the normal poll cycle
+
+#### Scenario: AgenticOLSConfig read fails
+- **WHEN** reading the `AgenticOLSConfig` suspension state fails for a reason other than absent CRD or absent singleton object
+- **THEN** the system logs the error and skips the reconcile cycle; the next poll retries
+
+#### Scenario: No AlertManager polling while suspended
+- **WHEN** the `AgenticOLSConfig` singleton named `cluster` exists with `spec.suspended` set to true and a reconcile cycle begins
+- **THEN** the system does not call the AlertManager API
+
+#### Scenario: No AgenticRun access while suspended
+- **WHEN** the `AgenticOLSConfig` singleton named `cluster` exists with `spec.suspended` set to true and a reconcile cycle begins
+- **THEN** the system does not list existing AgenticRuns and does not create any AgenticRun
+
+#### Scenario: AlertManager unreachable during poll
+- **WHEN** suspended mode is disabled and the AlertManager API returns an error during a poll cycle
+- **THEN** the system logs the error and skips the cycle; the next poll retries
+
+#### Scenario: Kubernetes API unreachable during poll
+- **WHEN** suspended mode is disabled and the Kubernetes API returns an error during AgenticRun listing or creation
+- **THEN** the system logs the error and skips the cycle; the next poll retries

--- a/openspec/changes/archive/2026-09-04-add-suspended-mode/tasks.md
+++ b/openspec/changes/archive/2026-09-04-add-suspended-mode/tasks.md
@@ -1,0 +1,22 @@
+## 1. AgenticOLSConfig Suspension Check
+
+- [x] 1.1 Add an `AgenticOLSConfig` client that gets the cluster-scoped singleton named `cluster` and returns `spec.suspended`
+- [x] 1.2 Treat missing `AgenticOLSConfig` CRD or singleton object as unsuspended, and return other read errors to the caller
+- [x] 1.3 Add a `SuspensionSource` to the adapter and check it before AlertManager or `AgenticRun` access in every reconcile cycle
+- [x] 1.4 Wire the `AgenticOLSConfig` client into `main` and remove the `SUSPENDED` startup gate
+
+## 2. Tests
+
+- [x] 2.1 Add table-driven adapter tests verifying suspended and suspension-read-error cycles do not call AlertManager or list or create `AgenticRun` resources
+- [x] 2.2 Add table-driven `AgenticOLSConfig` client tests for suspended, unsuspended, and missing singleton states
+- [x] 2.3 Run `go test ./...` and verify all tests pass
+
+## 3. Manifests and Documentation
+
+- [x] 3.1 Grant the adapter service account cluster-scoped `get` permission for `agenticolsconfigs`
+- [x] 3.2 Remove the `SUSPENDED` deployment example and document `AgenticOLSConfig.spec.suspended` behavior in the README and architecture documentation
+
+## 4. Validation
+
+- [x] 4.1 Update active and archived OpenSpec records to describe per-cycle `AgenticOLSConfig` suspension checks
+- [x] 4.2 Run `openspec validate --specs --strict` and verify the specs pass validation

--- a/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/design.md
+++ b/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The adapter lists existing AgenticRuns during each reconcile cycle and skips alerts that already have an active matching run. Terminal runs are handled by the post-run delay check.
+
+`EmergencyStopped` is a terminal phase in the AgenticRun API, but the adapter currently does not include it in its terminal phase handling. As a result, a matching EmergencyStopped run is treated as active and can block future processing indefinitely.
+
+The existing AgenticRun name is deterministic for an alert instance and includes the alert `startsAt` hash. For a still-firing alert, `startsAt` remains unchanged. Therefore, if the adapter tries to create a replacement run for the same still-firing alert, the original name may already be taken by the EmergencyStopped run.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Treat `EmergencyStopped` as terminal in adapter lifecycle checks.
+- Apply the configured post-run delay to EmergencyStopped runs.
+- Allow a new AgenticRun to be created for the same still-firing alert after post-run delay has elapsed.
+- Preserve the adapter's create-only behavior.
+- Keep the behavior stateless by deriving replacement names from existing AgenticRuns listed during the current cycle.
+
+**Non-Goals:**
+
+- Reading or interpreting global suspension state directly.
+- Deleting, updating, or mutating existing EmergencyStopped AgenticRuns.
+- Changing the post-run delay configuration model.
+
+## Decisions
+
+### 1. EmergencyStopped is terminal
+
+The adapter will include `EmergencyStopped` in terminal phase handling. Matching EmergencyStopped runs will no longer count as active runs.
+
+### 2. EmergencyStopped uses the normal post-run delay
+
+The adapter will use the EmergencyStopped condition transition time as the terminal time. If the configured post-run delay has not elapsed, the alert remains skipped. If the delay has elapsed, the alert can proceed to creation.
+
+This keeps retry behavior consistent with other terminal phases and avoids immediate repeated creation.
+
+### 3. Replacement runs use deterministic retry suffixes
+
+When the adapter is allowed to create a run for an alert whose original deterministic name is already used by an EmergencyStopped run, it will choose the next deterministic retry name based on existing runs.
+
+The first attempt keeps the existing name format. Replacement attempts append a suffix such as `-retry-1`, `-retry-2`, and so on.
+
+The suffix is chosen from the AgenticRuns returned by the current list call, so the adapter remains stateless.
+
+### 4. Existing deterministic naming remains unchanged for normal first attempts
+
+The existing name format remains the default. Retry suffixes are only used when needed to create a replacement after an EmergencyStopped run.
+
+## Risks / Trade-offs
+
+- **[Risk] Name length constraints** → Retry suffixes consume part of the 63-character name budget. The implementation must preserve the existing name-length guarantees by trimming the base name when needed.
+- **[Risk] Concurrent creators** → The adapter is designed as a single replica. If multiple instances run, two instances could choose the same retry suffix. Existing 409 handling remains the fallback.
+- **[Trade-off] More naming complexity** → Retry naming adds complexity, but it is required to create a replacement for the same still-firing alert while preserving create-only behavior.

--- a/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/proposal.md
+++ b/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The alerts adapter currently does not treat `EmergencyStopped` AgenticRuns as terminal. A stopped run can therefore continue to block processing for the same alert even though that run will not continue.
+
+When an alert is still firing after an emergency stop condition is no longer active, the adapter should be able to create a new AgenticRun after the configured post-run delay.
+
+## What Changes
+
+- Treat `EmergencyStopped` as a terminal AgenticRun phase.
+- Include `EmergencyStopped` runs in the normal post-run delay check.
+- Allow a replacement AgenticRun to be created for the same still-firing alert after the post-run delay has elapsed.
+- Preserve create-only behavior by using a deterministic retry suffix when the original AgenticRun name already exists.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `poll-loop`: EmergencyStopped AgenticRuns become terminal for active-run checks and participate in post-run delay.
+- `agenticrun-building`: Replacement AgenticRuns for previously EmergencyStopped alert instances can use deterministic retry names.
+
+## Impact
+
+- `internal/adapter/adapter.go` — terminal phase and terminal-time handling for EmergencyStopped.
+- `internal/agenticrun` — support deterministic replacement naming when an EmergencyStopped run already uses the original alert-derived name.
+- `internal/adapter/adapter_test.go` and related builder tests — cover EmergencyStopped active-run, post-run delay, and replacement-name behavior.

--- a/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/specs/agenticrun-building/spec.md
+++ b/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/specs/agenticrun-building/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Build replacement AgenticRuns after EmergencyStopped
+The system SHALL support creating a replacement AgenticRun for a still-firing alert when the original alert-derived AgenticRun name already exists for an EmergencyStopped run and the alert is eligible for creation.
+
+#### Scenario: Replacement AgenticRun after EmergencyStopped
+- **WHEN** an alert is still firing, the original deterministic AgenticRun name already exists for that alert instance, and the existing matching run is EmergencyStopped outside the configured post-run delay
+- **THEN** the system creates a replacement AgenticRun using the next deterministic retry name
+
+#### Scenario: Retry name preserves Kubernetes constraints
+- **WHEN** a replacement AgenticRun name requires a retry suffix
+- **THEN** the final name remains within the existing Kubernetes name length limit
+
+#### Scenario: Deterministic retry naming
+- **WHEN** the same set of existing AgenticRuns is evaluated for the same alert instance
+- **THEN** the same next retry name is selected

--- a/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/specs/poll-loop/spec.md
+++ b/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/specs/poll-loop/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Skip alerts with active AgenticRuns
+The system SHALL not create an AgenticRun for an alert that already has an active (non-terminal) AgenticRun, identified by matching the alert fingerprint label. `EmergencyStopped` SHALL be treated as terminal, not active.
+
+#### Scenario: Active AgenticRun exists for alert
+- **WHEN** an AgenticRun with matching fingerprint label exists and its phase is Pending, Analyzing, Proposed, Executing, Verifying, or Escalating
+- **THEN** the alert is skipped and logged at Debug level
+
+#### Scenario: EmergencyStopped AgenticRun exists for alert
+- **WHEN** the only AgenticRun with matching fingerprint label is in phase EmergencyStopped
+- **THEN** the alert passes the active-run check
+
+#### Scenario: No AgenticRun exists for alert
+- **WHEN** no AgenticRun with matching fingerprint label exists
+- **THEN** the alert passes the active-run check
+
+### Requirement: Skip alerts within post-run delay
+The system SHALL not create an AgenticRun for an alert that has a terminal AgenticRun (Completed, Failed, Denied, Escalated, EmergencyStopped) within the configured `postRunDelay` (default 1h), to avoid repeated analysis of an alert that has recently reached a terminal state. When `postRunDelay` is 0, this check is a no-op and all alerts pass.
+
+#### Scenario: postRunDelay is 0
+- **WHEN** `postRunDelay` is 0s
+- **THEN** all alerts pass the post-run delay check regardless of terminal AgenticRun timing
+
+#### Scenario: Terminal AgenticRun within postRunDelay
+- **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in a terminal phase and its terminal condition's `LastTransitionTime` is less than `postRunDelay` ago
+- **THEN** the alert is skipped and logged at Debug level
+
+#### Scenario: Terminal AgenticRun outside postRunDelay
+- **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in a terminal phase and its terminal condition's `LastTransitionTime` is equal to or greater than `postRunDelay` ago
+- **THEN** the alert passes the post-run delay check
+
+#### Scenario: EmergencyStopped AgenticRun within postRunDelay
+- **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in phase EmergencyStopped and its EmergencyStopped condition's `LastTransitionTime` is less than `postRunDelay` ago
+- **THEN** the alert is skipped and logged at Debug level
+
+#### Scenario: EmergencyStopped AgenticRun outside postRunDelay
+- **WHEN** `postRunDelay` is greater than 0 and an AgenticRun with matching fingerprint label is in phase EmergencyStopped and its EmergencyStopped condition's `LastTransitionTime` is equal to or greater than `postRunDelay` ago
+- **THEN** the alert passes the post-run delay check

--- a/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/tasks.md
+++ b/openspec/changes/archive/2026-09-04-handle-emergencystopped-agenticruns/tasks.md
@@ -1,0 +1,21 @@
+## 1. Terminal phase handling
+
+- [x] 1.1 Add `EmergencyStopped` to the adapter's terminal phase handling and verify active-run checks no longer treat it as active with unit tests.
+- [x] 1.2 Use the EmergencyStopped condition transition time for post-run delay evaluation and verify recent EmergencyStopped runs are skipped with unit tests.
+
+## 2. Replacement naming
+
+- [x] 2.1 Add deterministic retry-name selection for replacements when the original alert-derived AgenticRun name already exists and verify the next suffix is selected from existing runs with unit tests.
+- [x] 2.2 Preserve existing name sanitization and length constraints when adding retry suffixes and verify long names remain within the Kubernetes limit with unit tests.
+- [x] 2.3 Keep the existing first-attempt AgenticRun name format unchanged and verify existing builder tests continue to pass.
+
+## 3. Reconcile behavior
+
+- [x] 3.1 Ensure matching EmergencyStopped runs outside post-run delay allow replacement AgenticRun creation and verify with a reconcile-level unit test.
+- [x] 3.2 Ensure matching EmergencyStopped runs within post-run delay skip replacement AgenticRun creation and verify with a reconcile-level unit test.
+- [x] 3.3 Ensure active non-terminal runs still block creation and normal terminal phases still honor post-run delay by running the existing adapter test suite.
+
+## 4. Validation
+
+- [x] 4.1 Run `go test ./...` and verify all tests pass.
+- [x] 4.2 Run `openspec validate handle-emergencystopped-agenticruns --strict` and verify the change is valid.

--- a/openspec/specs/alert-retrieval/spec.md
+++ b/openspec/specs/alert-retrieval/spec.md
@@ -58,13 +58,17 @@ The system SHALL request only active, non-silenced, non-inhibited alerts from th
 - **WHEN** an alert has resolved and is no longer active
 - **THEN** the alert is not included in the response
 
-### Requirement: Log retrieved alerts on startup
-The system SHALL fetch alerts during startup and log a summary of the results using structured logging.
+### Requirement: Log retrieved alerts during initial reconcile
+The system SHALL fetch alerts during the initial reconcile cycle and log a summary of the results using structured logging when suspended mode is disabled. When suspended mode is enabled through `AgenticOLSConfig.spec.suspended`, the system SHALL skip alert retrieval for that reconcile cycle and SHALL log that the adapter is suspended.
 
 #### Scenario: Alerts fetched and logged
-- **WHEN** the adapter starts and successfully retrieves alerts
+- **WHEN** suspended mode is disabled and the initial reconcile cycle successfully retrieves alerts
 - **THEN** the system logs the number of alerts retrieved and key details for each alert
 
-#### Scenario: Alert retrieval fails on startup
-- **WHEN** the adapter starts and alert retrieval fails
-- **THEN** the system logs the error and exits with a non-zero status code
+#### Scenario: Alert retrieval fails during initial reconcile
+- **WHEN** suspended mode is disabled and alert retrieval fails during the initial reconcile cycle
+- **THEN** the system logs the error and the next poll retries
+
+#### Scenario: Alert retrieval skipped while suspended
+- **WHEN** `AgenticOLSConfig.spec.suspended` is true and a reconcile cycle begins
+- **THEN** the system does not fetch alerts and logs that the adapter is suspended

--- a/openspec/specs/poll-loop/spec.md
+++ b/openspec/specs/poll-loop/spec.md
@@ -3,26 +3,46 @@ Continuously poll AlertManager for firing alerts and create AgenticRun CRs for n
 
 ## Requirements
 ### Requirement: Poll AlertManager on a fixed interval
-The system SHALL read operational parameters (`pollInterval`, `preRunDelay`, `postRunDelay`) from the `ConfigSource` at the start of each reconcile cycle and use them for that cycle's filtering and deduplication rules. The default poll interval is 30 seconds. When the loaded `pollInterval` differs from the current ticker interval, the system SHALL reset the ticker to the new interval. The filter order SHALL be: receiver allowlist -> pre-run delay -> active AgenticRun -> post-run delay.
+The system SHALL read operational parameters (`pollInterval`, `preRunDelay`, `postRunDelay`) from the `ConfigSource` at the start of each reconcile cycle and use them for that cycle's filtering and deduplication rules. The default poll interval is 30 seconds. When the loaded `pollInterval` differs from the current ticker interval, the system SHALL reset the ticker to the new interval. The filter order SHALL be: receiver allowlist -> pre-run delay -> active AgenticRun -> post-run delay. At the start of each reconcile cycle, the system SHALL read the cluster-scoped `AgenticOLSConfig` singleton named `cluster`; when `spec.suspended` is true, the system SHALL skip that reconcile cycle before polling AlertManager, listing existing AgenticRuns, or creating AgenticRuns. When the `AgenticOLSConfig` CRD or singleton object is absent, the system SHALL behave as if suspended mode is disabled.
 
 #### Scenario: Normal poll cycle
-- **WHEN** the poll interval elapses
+- **WHEN** suspended mode is disabled and the poll interval elapses
 - **THEN** the system fetches alerts from AlertManager, lists existing AgenticRuns, applies receiver filtering then dedup rules, and creates AgenticRuns for qualifying alerts
 
 #### Scenario: Configuration loaded each cycle
-- **WHEN** a reconcile cycle begins
+- **WHEN** suspended mode is disabled and a reconcile cycle begins
 - **THEN** the system calls `ConfigSource.Load()` and uses the returned values for that cycle's pre-run delay check and post-run delay check
 
 #### Scenario: Poll interval changes between cycles
-- **WHEN** the `pollInterval` value from `ConfigSource.Load()` differs from the current ticker interval
+- **WHEN** suspended mode is disabled and the `pollInterval` value from `ConfigSource.Load()` differs from the current ticker interval
 - **THEN** the system resets the ticker to the new interval and logs the change
 
+#### Scenario: Suspended mode enabled
+- **WHEN** the `AgenticOLSConfig` singleton named `cluster` exists with `spec.suspended` set to true and a reconcile cycle begins
+- **THEN** the system logs that the adapter is suspended and skips the reconcile cycle
+
+#### Scenario: AgenticOLSConfig absent
+- **WHEN** the `AgenticOLSConfig` CRD or singleton object named `cluster` is absent and a reconcile cycle begins
+- **THEN** the system treats suspended mode as disabled and continues the normal poll cycle
+
+#### Scenario: AgenticOLSConfig read fails
+- **WHEN** reading the `AgenticOLSConfig` suspension state fails for a reason other than absent CRD or absent singleton object
+- **THEN** the system logs the error and skips the reconcile cycle; the next poll retries
+
+#### Scenario: No AlertManager polling while suspended
+- **WHEN** the `AgenticOLSConfig` singleton named `cluster` exists with `spec.suspended` set to true and a reconcile cycle begins
+- **THEN** the system does not call the AlertManager API
+
+#### Scenario: No AgenticRun access while suspended
+- **WHEN** the `AgenticOLSConfig` singleton named `cluster` exists with `spec.suspended` set to true and a reconcile cycle begins
+- **THEN** the system does not list existing AgenticRuns and does not create any AgenticRun
+
 #### Scenario: AlertManager unreachable during poll
-- **WHEN** the AlertManager API returns an error during a poll cycle
+- **WHEN** suspended mode is disabled and the AlertManager API returns an error during a poll cycle
 - **THEN** the system logs the error and skips the cycle; the next poll retries
 
 #### Scenario: Kubernetes API unreachable during poll
-- **WHEN** the Kubernetes API returns an error during AgenticRun listing or creation
+- **WHEN** suspended mode is disabled and the Kubernetes API returns an error during AgenticRun listing or creation
 - **THEN** the system logs the error and skips the cycle; the next poll retries
 
 ### Requirement: Skip transient alerts (pre-run delay)


### PR DESCRIPTION
Read the cluster-scoped AgenticOLSConfig singleton during each reconcile cycle and skip AlertManager and AgenticRun access when spec.suspended is true. Treat a missing CRD or config object as unsuspended, and add the required cluster RBAC, tests, specs, and documentation.

Signed-off-by: Tomáš Remeš <tremes@redhat.com>

Assisted-by: OpenAI:ChatGPT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added suspended mode controlled by the cluster-scoped `AgenticOLSConfig` resource.
  - When suspension is enabled, the adapter skips polling and avoids creating or accessing runs for that cycle.
  - Missing configuration keeps suspended mode disabled; configuration read errors are logged and retried on the next cycle.
  - Added required permissions to read suspension settings.

- **Documentation**
  - Documented suspended-mode behavior, configuration, and an example in the architecture documentation and README.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->